### PR TITLE
Fix some bugs around DKG and relocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,6 @@ mock = [
     "env_logger",
     "bls_signature_aggregator/mock_timer"
 ]
+
+[patch.crates-io]
+bls_signature_aggregator = { git = "https://github.com/madadam/bls_signature_aggregator.git", branch = "repetition" }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -353,12 +353,7 @@ fn handle_event(
             dst,
             HexFmt(content)
         ),
-        Event::RelocationInitiated { name, destination } => log::debug!(
-            "Node #{} initiated relocation of {} to {}",
-            index,
-            name,
-            destination
-        ),
+        Event::RelocationStarted => log::info!("Node #{} relocation started", index,),
         Event::Terminated => {
             log::info!("Node #{} terminated", index);
             return false;

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -297,8 +297,13 @@ fn handle_event(
                     .expect("failed to send contact info")
             }
         }
-        Event::Connected(Connected::Relocate) => {
-            log::info!("Node #{} relocated - new name: {}", index, node.name());
+        Event::Connected(Connected::Relocate { previous_name }) => {
+            log::info!(
+                "Node #{} relocated - old name: {}, new name: {}",
+                index,
+                previous_name,
+                node.name()
+            );
         }
         Event::PromotedToElder => {
             log::info!("Node #{} promoted to Elder", index);

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -358,7 +358,11 @@ fn handle_event(
             dst,
             HexFmt(content)
         ),
-        Event::RelocationStarted => log::info!("Node #{} relocation started", index,),
+        Event::RelocationStarted { previous_name } => log::info!(
+            "Node #{} relocation started - previous_name: {}",
+            index,
+            previous_name
+        ),
         Event::Terminated => {
             log::info!("Node #{} terminated", index);
             return false;

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -25,7 +25,7 @@ use std::{
 // more than two DKG sessions at the time (one during normal section update, two during split), but
 // in the case of heavy churn there can be more. Note also that this applies to DKG observers only.
 // A DKG participant has always at most one active session.
-const MAX_OBSERVERS: usize = 10;
+const MAX_OBSERVERS: usize = 20;
 
 /// Generate a BLS SecretKeySet for the given number of participants.
 /// Used for generating first node, or for test.
@@ -59,16 +59,15 @@ pub type DkgStatus<T> = Option<Result<T, EldersInfo>>;
 /// 1. First the current elders propose the new elder candidates in the form of `EldersInfo`
 ///    structure.
 /// 2. They send an accumulating message `DKGStart` containing this proposed `EldersInfo` to the
-///    other elders (DKG observers) and also to the candidates (DKG participants).
-/// 3. When it accumulates, a participant calls `start_participating`. An observer calls
-///    `start_observing`. Note a node can sometimes be both participant and observer at the same
-///    time.
+///    new elders candidates (DKG participants) and also call `start_observing` to initialize the
+///    DKG result accumulator.
+/// 3. When the `DKGStart` message accumulates, the participants call `start_participating`.
 /// 4. The participants keep exchanging the DKG messages and calling `process_dkg_message`.
 /// 5. The participants call `check_dkg` to check whether the DKG session completed or failed.
 /// 6. They should also run a timer in case of inactivity and call `progress_dkg` when it fires.
 /// 7. On DKG completion or failure, the participants send `DKGResult` message to the current
 ///    elders (observers)
-/// 8. The observers observer the result by calling `observe_result`.
+/// 8. The observers call `observe_result` with each received `DKGResult`.
 /// 9. When it returns success, that means we accumulated at least quorum of successful DKG results
 ///    and can proceed with voting for the section update.
 /// 10. When it fails, the observers restart the process from step 1.

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -142,6 +142,8 @@ impl DkgVoter {
 
     // Start a new DKG session as an observer.
     pub fn start_observing(&mut self, elders_info: EldersInfo) {
+        trace!("DKG for {} observing", elders_info);
+
         let _ = self
             .observers
             .entry(elders_info)

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -330,8 +330,10 @@ impl DkgVoter {
         };
 
         let elders_info = if result.is_ok() {
+            // On success, remove the sesssion because we don't need it anymore.
             self.observers.remove(dkg_key).unwrap().elders_info
         } else {
+            // On failure, only clear the accumulator to allow new votes from restarted DKG
             session.accumulator.clear();
             session.elders_info.clone()
         };

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -7,272 +7,361 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    id::{FullId, PublicId},
+    crypto::Digest256,
+    id::{FullId, P2pNode, PublicId},
     rng::MainRng,
-    section::EldersInfo,
-    QUORUM_DENOMINATOR, QUORUM_NUMERATOR,
+    section::{quorum_count, EldersInfo},
 };
-use bls::{PublicKeySet, SecretKeyShare};
-use bls_dkg::key_gen::{message::Message as DkgMessage, KeyGen};
+use bls_dkg::key_gen::{message::Message as DkgMessage, outcome::Outcome, KeyGen};
+use hex_fmt::HexFmt;
+use itertools::Itertools;
 use lru_time_cache::LruCache;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{HashMap, HashSet},
     fmt::{self, Debug, Formatter},
-    time::Duration,
 };
 
-const OLD_ELDERS_EXPIRY_DURATION: Duration = Duration::from_secs(2 * 60);
-
-/// Returns the number of minumn responsive participants expected for the DKG process
-#[inline]
-pub const fn threshold_count(elder_size: usize) -> usize {
-    // TODO: allow threshold to be configurable.
-    elder_size * QUORUM_NUMERATOR / QUORUM_DENOMINATOR
-}
-
-pub type DkgKey = (BTreeSet<PublicId>, u64);
+// Maximum number of DKG sessions we can observe at the same time. Normally there should be no
+// more than two DKG sessions at the time (one during normal section update, two during split), but
+// in the case of heavy churn there can be more. Note also that this applies to DKG observers only.
+// A DKG participant has always at most one active session.
+const MAX_OBSERVERS: usize = 10;
 
 /// Generate a BLS SecretKeySet for the given number of participants.
 /// Used for generating first node, or for test.
 pub fn generate_secret_key_set(rng: &mut MainRng, participants: usize) -> bls::SecretKeySet {
-    let threshold = threshold_count(participants);
+    let threshold = quorum_count(participants) - 1;
     bls::SecretKeySet::random(threshold, rng)
 }
 
-#[derive(Clone)]
-/// DKG result
-pub struct DkgResult {
-    /// Actual participants of the DKG. Excludes the non-participating nodes.
-    pub participants: BTreeSet<PublicId>,
-    /// Public key set to verify threshold signatures
-    pub public_key_set: PublicKeySet,
-    /// Secret Key share: None if the node was not participating in the DKG and did not receive
-    /// encrypted shares.
-    pub secret_key_share: Option<SecretKeyShare>,
-}
+/// Unique identified of a DKG session.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub struct DkgKey(Digest256);
 
-impl Debug for DkgResult {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        formatter
-            .debug_struct("DkgResult")
-            .field("participants", &self.participants)
-            .field("public_key", &self.public_key_set.public_key())
-            .field("secret_key_share", &self.secret_key_share.is_some())
-            .finish()
+impl DkgKey {
+    pub fn new(elders_info: &EldersInfo) -> Self {
+        Self(elders_info.hash())
     }
 }
 
-/// DKG voter carries out the work of voting for a DKG. Also contains the facility caches that
-/// allows sn_routing utilize the result properly within its churning process.
+impl Debug for DkgKey {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "DkgKey({:10})", HexFmt(&self.0))
+    }
+}
+
+pub type DkgStatus<T> = Option<Result<T, EldersInfo>>;
+
+/// DKG voter carries out the work of participating and/or observing a DKG.
+///
+/// # Usage
+///
+/// 1. First the current elders propose the new elder candidates in the form of `EldersInfo`
+///    structure.
+/// 2. They send an accumulating message `DKGStart` containing this proposed `EldersInfo` to the
+///    other elders (DKG observers) and also to the candidates (DKG participants).
+/// 3. When it accumulates, a participant calls `start_participating`. An observer calls
+///    `start_observing`. Note a node can sometimes be both participant and observer at the same
+///    time.
+/// 4. The participants keep exchanging the DKG messages and calling `process_dkg_message`.
+/// 5. The participants call `check_dkg` to check whether the DKG session completed or failed.
+/// 6. They should also run a timer in case of inactivity and call `progress_dkg` when it fires.
+/// 7. On DKG completion or failure, the participants send `DKGResult` message to the current
+///    elders (observers)
+/// 8. The observers observer the result by calling `observe_result`.
+/// 9. When it returns success, that means we accumulated at least quorum of successful DKG results
+///    and can proceed with voting for the section update.
+/// 10. When it fails, the observers restart the process from step 1.
+///
+/// Note: in case of heavy churn, it can happen that more than one DKG session completes
+/// successfully. Some kind of disambiguation strategy needs to be employed in that case, but that
+/// is currently not a responsibility of this module.
 pub struct DkgVoter {
-    // Holds the info of the expected new elders.
-    dkg_cache: BTreeMap<DkgKey, EldersInfo>,
-    // Holds the key generator that carries out the DKG voting procedure.
-    key_gen_map: HashMap<DkgKey, KeyGen<FullId>>,
-    // Cache of notified dkg_result. During split or demote,
-    // old elders will be notified by the new elders.
-    dkg_result_cache: BTreeMap<DkgKey, DkgResult>,
-    // section_key_index of the latest completed DKG.
-    current_section_key_index: u64,
-    // Cache of DKGOldElders notifications.
-    old_elders_notifications: LruCache<BTreeSet<PublicId>, BTreeSet<PublicId>>,
-    timer_token: u64,
+    participant: Option<Participant>,
+    observers: LruCache<EldersInfo, Observer>,
 }
 
 impl Default for DkgVoter {
     fn default() -> Self {
         Self {
-            dkg_cache: Default::default(),
-            key_gen_map: Default::default(),
-            dkg_result_cache: Default::default(),
-            current_section_key_index: 0,
-            old_elders_notifications: LruCache::with_expiry_duration(OLD_ELDERS_EXPIRY_DURATION),
-            timer_token: 0,
+            participant: None,
+            observers: LruCache::with_capacity(MAX_OBSERVERS),
         }
     }
 }
 
 impl DkgVoter {
-    // Check whether a key generator is finalized to give a DKG.
-    pub fn check_dkg(&mut self) -> BTreeMap<DkgKey, DkgResult> {
-        let mut completed = BTreeMap::new();
-        for (key, key_gen) in self.key_gen_map.iter_mut() {
-            if key_gen.is_finalized() {
-                let dkg_key = (key.0.clone(), key.1);
-                if let Some((participants, dkg_outcome)) = key_gen.generate_keys() {
-                    let dkg_result = DkgResult {
-                        participants,
-                        public_key_set: dkg_outcome.public_key_set,
-                        secret_key_share: Some(dkg_outcome.secret_key_share),
-                    };
-                    let _ = completed.insert(dkg_key.clone(), dkg_result);
-                }
+    // Starts a new DKG session as a participant. The caller should broadcast the returned messages
+    // to the other DKG participants.
+    pub fn start_participating(
+        &mut self,
+        full_id: &FullId,
+        elders_info: EldersInfo,
+    ) -> Option<(DkgKey, DkgMessage<PublicId>)> {
+        if let Some(current_elders_info) = self
+            .participant
+            .as_ref()
+            .and_then(|session| session.elders_info.as_ref())
+        {
+            if *current_elders_info == elders_info {
+                trace!("DKG for {} already in progress", elders_info);
+                return None;
             }
         }
 
-        completed
-    }
+        let threshold = quorum_count(elders_info.elders.len()) - 1;
+        let participants = elders_info
+            .elders
+            .values()
+            .map(P2pNode::public_id)
+            .copied()
+            .collect();
 
-    // Free key generators not newer than the current one.
-    // After a DKG completion, sn_routing will carry out votes of OurKey and SectionInfo.
-    // Only after these votes got consensused, will then the section_key_index got updated.
-    // So, a sn_routing level check of section_index will not be enough within the gap.
-    // i.e. any DKG message received during the gap will cause a new round of DKG for the same.
-    // Hence here the info of completed highest section_key_index shall be recorded and checked
-    // against to cover the gap.
-    pub fn remove_voter(&mut self, current_section_key_index: u64) {
-        self.key_gen_map
-            .retain(|key, _| key.1 > current_section_key_index);
-        self.current_section_key_index =
-            std::cmp::max(self.current_section_key_index, current_section_key_index);
-    }
+        match KeyGen::initialize(full_id, threshold, participants) {
+            Ok((key_gen, message)) => {
+                trace!("DKG for {} starting", elders_info);
 
-    // Make key generator progress with timed phase. Returns with DkgMessages to broadcast if any.
-    pub fn progress_dkg(&mut self, rng: &mut MainRng) -> Vec<(DkgKey, DkgMessage<PublicId>)> {
-        let mut broadcast = Vec::new();
-        let mut blocked = Vec::new();
-        for (key, key_gen) in self.key_gen_map.iter_mut() {
-            debug!("Progressing DKG {:?}", key);
-            if let Ok(messages) = key_gen.timed_phase_transition(rng) {
-                for message in messages {
-                    broadcast.push((key.clone(), message));
-                }
-            } else {
-                // Whenever there is an error, we consider such dkg process is blocked and shall be
-                // discarded.
-                blocked.push(key.clone());
+                let dkg_key = DkgKey::new(&elders_info);
+
+                self.participant = Some(Participant {
+                    dkg_key,
+                    key_gen,
+                    elders_info: Some(elders_info),
+                    timer_token: 0,
+                });
+
+                Some((dkg_key, message))
+            }
+            Err(error) => {
+                debug!("DKG for {} failed to start: {}", elders_info, error);
+
+                None
             }
         }
-
-        for dkg_key in blocked.iter() {
-            debug!("discarding DKG voter {:?}", dkg_key);
-            let _ = self.dkg_cache.remove(dkg_key);
-            let _ = self.key_gen_map.remove(dkg_key);
-        }
-
-        broadcast
     }
 
-    // Handle a received DkgMessage. Returns with DkgMessages to broadcast if any.
+    // Start a new DKG session as an observer.
+    pub fn start_observing(&mut self, elders_info: EldersInfo) {
+        let _ = self
+            .observers
+            .entry(elders_info)
+            .or_insert_with(Default::default);
+    }
+
+    // Check whether a key generator is finalized to give a DKG outcome.
+    //
+    // Returns:
+    // - `Some(Ok((elders_info, outcome)))` if the DKG successfully completed
+    // - `Some(Err(elders_info))` if the DKG failed
+    // - `None` if the DKG is still in progress or if there is no active DKG session.
+    //
+    // A returned `Some` should be sent to the DKG observers for accumulation.
+    pub fn check_dkg(&mut self) -> DkgStatus<(EldersInfo, Outcome)> {
+        let session = self.participant.as_mut()?;
+        let _ = session.elders_info.as_ref()?;
+
+        if !session.key_gen.is_finalized() {
+            return None;
+        }
+
+        let (participants, outcome) = session.key_gen.generate_keys()?;
+
+        // This is OK to `unwrap` because we already checked it is `Some`.
+        let elders_info = session.elders_info.take().unwrap();
+
+        if participants
+            .iter()
+            .eq(elders_info.elders.values().map(P2pNode::public_id))
+        {
+            trace!(
+                "DKG for {} complete: {:?}",
+                elders_info,
+                outcome.public_key_set.public_key()
+            );
+
+            // Note: we keep `self.participant` set because other nodes might still need to receive
+            // DKG messages from us for them to complete.
+
+            Some(Ok((elders_info, outcome)))
+        } else {
+            trace!(
+                "DKG for {} failed: unexpected participants: {:?}",
+                elders_info,
+                participants.iter().map(PublicId::name).format(", ")
+            );
+
+            self.participant = None;
+
+            Some(Err(elders_info))
+        }
+    }
+
+    // Make key generator progress with timed phase.
+    //
+    // Returns:
+    // - `Some(Ok((dkg_key, messages)))` if the DKG is still in progress. The returned messages
+    //   should be broadcast to the other participants.
+    // - `Some(Err(elders_info))` if the DKG failed. The result should be sent to the DKG observers
+    //   for accumulation.
+    // - `None` if there is no active DKG session.
+    pub fn progress_dkg(
+        &mut self,
+        rng: &mut MainRng,
+    ) -> DkgStatus<(DkgKey, Vec<DkgMessage<PublicId>>)> {
+        let session = self.participant.as_mut()?;
+        let elders_info = session.elders_info.as_ref()?;
+
+        trace!("DKG for {} progressing", elders_info);
+
+        match session.key_gen.timed_phase_transition(rng) {
+            Ok(messages) => Some(Ok((session.dkg_key, messages))),
+            Err(error) => {
+                trace!("DKG for {} failed: {}", elders_info, error);
+
+                // This is OK to `unwrap` because we already checked it is `Some`.
+                let elders_info = session.elders_info.take().unwrap();
+
+                self.participant = None;
+
+                Some(Err(elders_info))
+            }
+        }
+    }
+
+    /// Returns the participants of the DKG session, if there is one.
+    pub fn participants(&self) -> impl Iterator<Item = &P2pNode> {
+        self.participant
+            .as_ref()
+            .and_then(|session| session.elders_info.as_ref())
+            .into_iter()
+            .flat_map(|elders_info| elders_info.elders.values())
+    }
+
+    // Handle a received DkgMessage. Returns with DkgMessages to broadcast to the other
+    // participants, if any.
     pub fn process_dkg_message(
         &mut self,
         rng: &mut MainRng,
         dkg_key: &DkgKey,
         message: DkgMessage<PublicId>,
     ) -> Vec<DkgMessage<PublicId>> {
-        if let Some(key_gen) = self.key_gen_map.get_mut(dkg_key) {
-            if let Ok(responses) = key_gen.handle_message(rng, message) {
-                return responses;
-            }
-        }
-        vec![]
-    }
+        let session = if let Some(session) = &mut self.participant {
+            session
+        } else {
+            return vec![];
+        };
 
-    // Startup a key generator.
-    pub fn init_dkg_gen(
-        &mut self,
-        full_id: &FullId,
-        dkg_key: &DkgKey,
-    ) -> Vec<DkgMessage<PublicId>> {
-        if (self.current_section_key_index > 0 && self.current_section_key_index >= dkg_key.1)
-            || self.key_gen_map.iter().any(|(key, _)| key.1 == dkg_key.1)
-        {
-            trace!("already have key_gen of {:?}", dkg_key);
+        if session.dkg_key != *dkg_key {
             return vec![];
         }
 
-        let threshold = threshold_count(dkg_key.0.len());
-
-        if let Ok((key_gen, message)) = KeyGen::initialize(full_id, threshold, dkg_key.0.clone()) {
-            debug!("started key_gen of {:?}", dkg_key);
-
-            let _ = self.key_gen_map.insert(dkg_key.clone(), key_gen);
-            vec![message]
-        } else {
-            vec![]
-        }
+        session
+            .key_gen
+            .handle_message(rng, message)
+            .unwrap_or_default()
     }
 
-    // Check whether we have the EldersInfo for the DkgResult that sent to us.
-    // In case we don't have, indicates we don't notice the churn yet,
-    // the dkg_result shall be cached.
-    pub fn has_info(
+    // Observer and accumulate a DKG result (either success or failure).
+    //
+    // Returns:
+    // - `Some(Result)` if the results accumulated
+    // - `None` if more results are still needed
+    pub fn observe_result(
         &mut self,
-        dkg_key: &DkgKey,
-        dkg_result: &DkgResult,
-        current_section_key_index: u64,
-    ) -> bool {
-        if self.dkg_cache.contains_key(dkg_key) {
-            true
-        } else {
-            // During split or demote, DKG got completed before this elder notice the churn.
-            // In this case, as this elder is responsible for voting SectionInfo and Key,
-            // the notified result has to be cached.
-            if current_section_key_index <= dkg_key.1 {
-                let _ = self
-                    .dkg_result_cache
-                    .insert(dkg_key.clone(), dkg_result.clone());
+        elders_info: &EldersInfo,
+        result: Result<bls::PublicKey, ()>,
+        sender: PublicId,
+    ) -> Option<Result<bls::PublicKey, ()>> {
+        if !elders_info.elders.contains_key(sender.name()) {
+            return None;
+        }
+
+        // Avoid updating the LRU list if the entry already exists.
+        if self
+            .observers
+            .peek(elders_info)
+            .and_then(|session| session.accumulator.get(&result))
+            .map(|ids| ids.contains(&sender))
+            .unwrap_or(false)
+        {
+            return None;
+        }
+
+        let session = self.observers.get_mut(elders_info)?;
+
+        let _ = session
+            .accumulator
+            .entry(result)
+            .or_default()
+            .insert(sender);
+
+        let total: usize = session.accumulator.values().map(|ids| ids.len()).sum();
+        let missing = elders_info.elders.len() - total;
+        let quorum = quorum_count(elders_info.elders.len());
+
+        let output = if let Some((public_key, count)) = session
+            .accumulator
+            .iter()
+            .filter_map(|(result, ids)| result.ok().map(|key| (key, ids.len())))
+            .max_by_key(|(_, count)| *count)
+        {
+            // At least one successful result
+
+            if count >= quorum {
+                // Successful quorum reached
+                Some(Ok(public_key))
+            } else if count + missing >= quorum {
+                // Successful quorum is still possible
+                None
+            } else {
+                // Successful quorum is no longer possible
+                Some(Err(()))
             }
-            false
-        }
-    }
-
-    // When a churn is noticed, the new EdlersInfo that calculated shall be recorded.
-    // In case we already have the correspondent DkgResult, the dkg_result shall be returned for
-    // sn_routing to carry out further process.
-    pub fn push_info(&mut self, dkg_key: &DkgKey, info: EldersInfo) -> Option<DkgResult> {
-        let _ = self.dkg_cache.insert(dkg_key.clone(), info);
-
-        if let Some(dkg_result) = self.dkg_result_cache.remove(dkg_key) {
-            Some(dkg_result)
         } else {
-            None
+            // No successful results yet
+
+            if missing >= quorum {
+                // Successful quorum is still possible
+                None
+            } else {
+                // Successful quorum is no longer possible
+                Some(Err(()))
+            }
+        };
+
+        if output.is_some() {
+            let _ = self.observers.remove(elders_info);
         }
+
+        output
     }
 
-    // Give the cached new EldersInfo to sn_routing for its further process.
-    pub fn take_info(&mut self, dkg_key: &DkgKey) -> Option<EldersInfo> {
-        self.dkg_cache.remove(dkg_key)
+    // Returns the timer token of the active DKG session if there is one. If this timer fires, we
+    // should call `progress_dkg`.
+    pub fn timer_token(&self) -> Option<u64> {
+        self.participant.as_ref().map(|session| session.timer_token)
     }
 
-    // Give the keys of cached new EldersInfo.
-    pub fn info_keys(&self) -> impl Iterator<Item = &DkgKey> {
-        self.dkg_cache.keys()
-    }
-
-    // Cache the dkg result that we got notified, indicates we are an old elder.
-    pub fn insert_old_elders_dkg_result(&mut self, dkg_key: DkgKey, dkg_result: DkgResult) {
-        let _ = self.dkg_result_cache.insert(dkg_key, dkg_result);
-    }
-
-    pub fn timer_token(&self) -> u64 {
-        self.timer_token
-    }
-
+    // Sets the timer token for the active DKG session. This should be set after a successful DKG
+    // initialization, or after handling a DKG message that produced at least one response.
     pub fn set_timer_token(&mut self, token: u64) {
-        self.timer_token = token;
-    }
-
-    // Return with true only when accumulated quorum valid notifications first time.
-    pub fn add_old_elders_notification(
-        &mut self,
-        participants: &BTreeSet<PublicId>,
-        src_id: &PublicId,
-    ) -> bool {
-        if !participants.contains(src_id) {
-            return false;
+        if let Some(session) = &mut self.participant {
+            session.timer_token = token;
         }
-
-        let senders = self
-            .old_elders_notifications
-            .entry(participants.clone())
-            .or_insert(BTreeSet::new());
-        let _ = senders.insert(*src_id);
-        senders.len() == threshold_count(participants.len())
     }
+}
 
-    // Returns whether there is live dkg_voter
-    pub fn has_live_dkg_voter(&self) -> bool {
-        !self.key_gen_map.is_empty()
-    }
+// Data for a DKG participant.
+struct Participant {
+    // `None` means the session is completed.
+    elders_info: Option<EldersInfo>,
+    dkg_key: DkgKey,
+    key_gen: KeyGen<FullId>,
+    timer_token: u64,
+}
+
+// Data for a DKG observer.
+#[derive(Default)]
+struct Observer {
+    accumulator: HashMap<Result<bls::PublicKey, ()>, HashSet<PublicId>>,
 }

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -14,7 +14,7 @@ pub mod test_utils;
 mod vote;
 
 pub use self::{
-    dkg::{generate_secret_key_set, threshold_count, DkgKey, DkgResult, DkgVoter},
+    dkg::{generate_secret_key_set, DkgKey, DkgVoter},
     proven::Proven,
     vote::{Vote, VoteAccumulator},
 };

--- a/src/consensus/vote.rs
+++ b/src/consensus/vote.rs
@@ -75,7 +75,7 @@ impl Vote {
 
 // Accumulator of `Vote`s.
 #[derive(Default)]
-pub struct VoteAccumulator(SignatureAggregator<SignableWrapper>);
+pub struct VoteAccumulator(SignatureAggregator);
 
 impl VoteAccumulator {
     pub fn add(

--- a/src/event.rs
+++ b/src/event.rs
@@ -21,7 +21,10 @@ pub enum Connected {
     /// Node first joining the network
     First,
     /// Node relocating from one section to another
-    Relocate,
+    Relocate {
+        /// Previous name before relocation.
+        previous_name: XorName,
+    },
 }
 
 /// An Event raised by a `Node` or `Client` via its event sender.

--- a/src/event.rs
+++ b/src/event.rs
@@ -89,7 +89,10 @@ pub enum Event {
     },
     /// This node has started relocating to other section. Will be followed by
     /// `Connected(Relocate)` when the node finishes joining the destination section.
-    RelocationStarted,
+    RelocationStarted {
+        /// Previous name before relocation
+        previous_name: XorName,
+    },
     /// Disconnected or failed to connect - restart required.
     RestartRequired,
     /// Startup failed - terminate.
@@ -140,7 +143,10 @@ impl Debug for Event {
                 .field("key", key)
                 .field("elders", elders)
                 .finish(),
-            Self::RelocationStarted => write!(formatter, "RelocationStarted"),
+            Self::RelocationStarted { previous_name } => formatter
+                .debug_struct("RelocationStarted")
+                .field("previous_name", previous_name)
+                .finish(),
             Self::RestartRequired => write!(formatter, "RestartRequired"),
             Self::Terminated => write!(formatter, "Terminated"),
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -84,15 +84,9 @@ pub enum Event {
         /// The set of elders of our section.
         elders: BTreeSet<XorName>,
     },
-    /// A node has been chosen for relocation.
-    /// Note: this event is useful mostly for debugging and testing purposes and can be safely
-    /// ignored in production.
-    RelocationInitiated {
-        /// Original (pre-relocation) name of the node to relocate.
-        name: XorName,
-        /// Destination to relocate the node to.
-        destination: XorName,
-    },
+    /// This node has started relocating to other section. Will be followed by
+    /// `Connected(Relocate)` when the node finishes joining the destination section.
+    RelocationStarted,
     /// Disconnected or failed to connect - restart required.
     RestartRequired,
     /// Startup failed - terminate.
@@ -143,11 +137,7 @@ impl Debug for Event {
                 .field("key", key)
                 .field("elders", elders)
                 .finish(),
-            Self::RelocationInitiated { name, destination } => formatter
-                .debug_struct("RelocationInitiated")
-                .field("name", name)
-                .field("destination", destination)
-                .finish(),
+            Self::RelocationStarted => write!(formatter, "RelocationStarted"),
             Self::RestartRequired => write!(formatter, "RestartRequired"),
             Self::Terminated => write!(formatter, "Terminated"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,10 +107,7 @@ pub mod rng;
 
 /// Mock network
 #[cfg(feature = "mock")]
-pub use self::{
-    consensus::threshold_count,
-    section::{quorum_count, MIN_AGE},
-};
+pub use self::section::{quorum_count, MIN_AGE};
 
 #[cfg(feature = "mock")]
 #[doc(hidden)]

--- a/src/messages/message_accumulator.rs
+++ b/src/messages/message_accumulator.rs
@@ -15,7 +15,7 @@ use serde::{Serialize, Serializer};
 
 /// Accumulator for section-source messages.
 #[derive(Default)]
-pub(crate) struct MessageAccumulator(SignatureAggregator<Payload>);
+pub(crate) struct MessageAccumulator(SignatureAggregator);
 
 impl MessageAccumulator {
     /// Add `AccumulatingMessage` to the accumulator. Returns the full `Message` if we have enough
@@ -50,8 +50,7 @@ impl MessageAccumulator {
                     }
                 }
             }
-            Err(AccumulationError::NotEnoughShares)
-            | Err(AccumulationError::AlreadyAccumulated) => None,
+            Err(AccumulationError::NotEnoughShares) => None,
             Err(error) => {
                 error!("Failed to add accumulating message: {}", error);
                 None

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -74,18 +74,23 @@ pub(crate) enum Variant {
         message: Bytes,
     },
     /// Sent to the new elder candidates to start the DKG process.
-    DKGStart(EldersInfo),
+    DKGStart {
+        /// The identifier of the DKG session to start.
+        dkg_key: DkgKey,
+        /// The DKG particpants.
+        elders_info: EldersInfo,
+    },
     /// Message exchanged for DKG process.
     DKGMessage {
-        /// The identifier of the key_gen instance this message is about.
+        /// The identifier of the DKG session this message is for.
         dkg_key: DkgKey,
         /// The serialized DKG message.
         message: Bytes,
     },
     /// Message to notify current elders about the DKG result.
     DKGResult {
-        /// The `EldersInfo` the DKG is for.
-        elders_info: EldersInfo,
+        /// The identifier of the DKG session the result is for.
+        dkg_key: DkgKey,
         /// The result of the DKG.
         result: Result<bls::PublicKey, ()>,
     },
@@ -168,18 +173,22 @@ impl Debug for Variant {
                 .field("src_key", src_key)
                 .field("message_hash", &MessageHash::from_bytes(message))
                 .finish(),
-            Self::DKGStart(info) => f.debug_tuple("DKGStart").field(info).finish(),
+            Self::DKGStart {
+                dkg_key,
+                elders_info,
+            } => f
+                .debug_struct("DKGStart")
+                .field("dkg_key", dkg_key)
+                .field("elders_info", elders_info)
+                .finish(),
             Self::DKGMessage { dkg_key, message } => f
                 .debug_struct("DKGMessage")
                 .field("dkg_key", &dkg_key)
                 .field("message_hash", &MessageHash::from_bytes(message))
                 .finish(),
-            Self::DKGResult {
-                elders_info,
-                result,
-            } => f
+            Self::DKGResult { dkg_key, result } => f
                 .debug_struct("DKGResult")
-                .field("elders_info", elders_info)
+                .field("dkg_key", dkg_key)
                 .field("result", result)
                 .finish(),
             Self::Vote {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -690,7 +690,10 @@ impl Node {
                         message.clone(),
                         src_key,
                     ),
-                Variant::DKGStart(info) => stage.handle_dkg_start(&mut self.core, info.clone())?,
+                Variant::DKGStart {
+                    dkg_key,
+                    elders_info,
+                } => stage.handle_dkg_start(&mut self.core, *dkg_key, elders_info.clone())?,
                 Variant::DKGMessage { dkg_key, message } => {
                     stage.handle_dkg_message(
                         &mut self.core,
@@ -699,13 +702,10 @@ impl Node {
                         *msg.src().as_node()?,
                     )?;
                 }
-                Variant::DKGResult {
-                    elders_info,
-                    result,
-                } => {
+                Variant::DKGResult { dkg_key, result } => {
                     stage.handle_dkg_result(
                         &mut self.core,
-                        elders_info.clone(),
+                        *dkg_key,
                         *result,
                         *msg.src().as_node()?,
                     )?;
@@ -1007,7 +1007,7 @@ impl Node {
     // Simulate DKG completion
     pub(crate) fn complete_dkg(
         &mut self,
-        elders_info: EldersInfo,
+        elders_info: &EldersInfo,
         public_key_set: bls::PublicKeySet,
         secret_key_share: Option<bls::SecretKeyShare>,
     ) -> Result<()> {

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -843,7 +843,7 @@ impl Approved {
         dkg_key: DkgKey,
         new_elders_info: EldersInfo,
     ) -> Result<()> {
-        trace!("Received DKGStart({:?})", new_elders_info);
+        trace!("Received DKGStart for {}", new_elders_info);
 
         if let Some(message) =
             self.dkg_voter
@@ -1329,6 +1329,8 @@ impl Approved {
 
         self.section_keys_provider
             .finalise_dkg(self.shared_state.our_history.last_key());
+        self.dkg_voter
+            .stop_observing(self.shared_state.our_history.last_key_index());
 
         let new_is_elder = self.is_our_elder(core.id());
         let new_last_key_index = self.shared_state.our_history.last_key_index();
@@ -1550,7 +1552,7 @@ impl Approved {
     }
 
     fn send_dkg_start(&mut self, core: &mut Core, new_elders_info: EldersInfo) -> Result<()> {
-        trace!("Send DKGStart({:?})", new_elders_info);
+        trace!("Send DKGStart for {}", new_elders_info);
 
         let dkg_key = DkgKey::new(&new_elders_info);
 
@@ -1577,7 +1579,11 @@ impl Approved {
 
         core.send_message_to_targets(&recipients, recipients.len(), message.to_bytes());
 
-        self.dkg_voter.start_observing(dkg_key, new_elders_info);
+        self.dkg_voter.start_observing(
+            dkg_key,
+            new_elders_info,
+            self.shared_state.our_history.last_key_index(),
+        );
 
         Ok(())
     }

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -1247,7 +1247,7 @@ impl Approved {
         if self.shared_state.our_history.has_key(&public_key) {
             // Our shared state is already up to date, so no need to vote. Just finalize the DKG so
             // we can start using the new secret key share.
-            self.section_keys_provider.finalise_dkg();
+            self.section_keys_provider.finalise_dkg(&public_key);
             return Ok(());
         }
 
@@ -1326,7 +1326,8 @@ impl Approved {
         let neighbour_elders_removed = neighbour_elders_removed.build(&self.shared_state.sections);
         self.prune_neighbour_connections(core, &neighbour_elders_removed);
 
-        self.section_keys_provider.finalise_dkg();
+        self.section_keys_provider
+            .finalise_dkg(self.shared_state.our_history.last_key());
 
         let new_is_elder = self.is_our_elder(core.id());
         let new_last_key_index = self.shared_state.our_history.last_key_index();

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -614,7 +614,9 @@ impl Approved {
         );
 
         if self.relocate_promise.is_none() {
-            core.send_event(Event::RelocationStarted);
+            core.send_event(Event::RelocationStarted {
+                previous_name: *core.name(),
+            });
         }
 
         let conn_infos: Vec<_> = self
@@ -650,7 +652,9 @@ impl Approved {
             // Keep it around even if we are not elder anymore, in case we need to resend it.
             if self.relocate_promise.is_none() {
                 self.relocate_promise = Some(msg_bytes.clone());
-                core.send_event(Event::RelocationStarted);
+                core.send_event(Event::RelocationStarted {
+                    previous_name: *core.name(),
+                });
             } else {
                 trace!("ignore RelocatePromise - already have one");
             }

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -221,7 +221,7 @@ impl Approved {
         let node = self
             .shared_state
             .our_members
-            .active()
+            .joined()
             .map(|info| &info.p2p_node)
             .find(|node| *node.peer_addr() == addr);
 
@@ -1044,7 +1044,7 @@ impl Approved {
 
             let addr = *info.p2p_node.peer_addr();
 
-            self.cast_unordered_vote(core, Vote::Offline(info.leave()))?;
+            self.cast_unordered_vote(core, Vote::Offline(info.relocate(*action.destination())))?;
 
             match action {
                 RelocateAction::Instant(details) => self.send_relocate(core, addr, details)?,

--- a/src/node/stage/approved.rs
+++ b/src/node/stage/approved.rs
@@ -1250,6 +1250,14 @@ impl Approved {
             return Ok(());
         }
 
+        if !self.section_update_barrier.start_update(elders_info.prefix) {
+            trace!(
+                "section update of {:?} already in progress",
+                elders_info.prefix
+            );
+            return Ok(());
+        }
+
         // Casting unordered_votes will check consensus and handle accumulated immediately.
         self.cast_unordered_vote(
             core,
@@ -1351,6 +1359,7 @@ impl Approved {
                     self.shared_state.our_info().elders.values().format(", ")
                 );
 
+                self.promote_and_demote_elders(core)?;
                 self.print_network_stats();
             }
 

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -72,9 +72,7 @@ impl Bootstrapping {
 
             Variant::NeighbourInfo { .. }
             | Variant::UserMessage(_)
-            | Variant::BouncedUntrustedMessage(_)
-            | Variant::DKGMessage { .. }
-            | Variant::DKGOldElders { .. } => Ok(MessageStatus::Unknown),
+            | Variant::BouncedUntrustedMessage(_) => Ok(MessageStatus::Unknown),
 
             Variant::NodeApproval(_)
             | Variant::Sync { .. }
@@ -85,7 +83,10 @@ impl Bootstrapping {
             | Variant::JoinRequest(_)
             | Variant::Ping
             | Variant::BouncedUnknownMessage { .. }
-            | Variant::Vote { .. } => Ok(MessageStatus::Useless),
+            | Variant::Vote { .. }
+            | Variant::DKGResult { .. }
+            | Variant::DKGStart(_)
+            | Variant::DKGMessage { .. } => Ok(MessageStatus::Useless),
         }
     }
 

--- a/src/node/stage/bootstrapping.rs
+++ b/src/node/stage/bootstrapping.rs
@@ -85,7 +85,7 @@ impl Bootstrapping {
             | Variant::BouncedUnknownMessage { .. }
             | Variant::Vote { .. }
             | Variant::DKGResult { .. }
-            | Variant::DKGStart(_)
+            | Variant::DKGStart { .. }
             | Variant::DKGMessage { .. } => Ok(MessageStatus::Useless),
         }
     }

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -99,7 +99,7 @@ impl Joining {
             | Variant::MessageSignature(_)
             | Variant::BouncedUntrustedMessage(_)
             | Variant::BouncedUnknownMessage { .. }
-            | Variant::DKGStart(_)
+            | Variant::DKGStart { .. }
             | Variant::DKGMessage { .. }
             | Variant::DKGResult { .. }
             | Variant::Vote { .. } => Ok(MessageStatus::Unknown),

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -153,9 +153,11 @@ impl Joining {
 
     // Are we relocating or joining for the first time?
     pub fn connect_type(&self) -> Connected {
-        match self.join_type {
+        match &self.join_type {
             JoinType::First { .. } => Connected::First,
-            JoinType::Relocate(_) => Connected::Relocate,
+            JoinType::Relocate(payload) => Connected::Relocate {
+                previous_name: *payload.relocate_details().pub_id.name(),
+            },
         }
     }
 

--- a/src/node/stage/joining.rs
+++ b/src/node/stage/joining.rs
@@ -99,8 +99,9 @@ impl Joining {
             | Variant::MessageSignature(_)
             | Variant::BouncedUntrustedMessage(_)
             | Variant::BouncedUnknownMessage { .. }
+            | Variant::DKGStart(_)
             | Variant::DKGMessage { .. }
-            | Variant::DKGOldElders { .. }
+            | Variant::DKGResult { .. }
             | Variant::Vote { .. } => Ok(MessageStatus::Unknown),
 
             Variant::BootstrapRequest(_)

--- a/src/node/tests/elder.rs
+++ b/src/node/tests/elder.rs
@@ -208,7 +208,7 @@ impl Env {
 
     fn simulate_dkg(&mut self, new_info: &DkgToSectionInfo) -> Result<()> {
         self.subject.complete_dkg(
-            new_info.new_elders_info.clone(),
+            &new_info.new_elders_info,
             new_info.new_pk_set.clone(),
             new_info.secret_key_share.clone(),
         )

--- a/src/section/elders_info.rs
+++ b/src/section/elders_info.rs
@@ -6,9 +6,9 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{crypto::Digest256, id::P2pNode, Prefix, XorName};
 #[cfg(test)]
 use crate::{id::FullId, rng::MainRng};
+use crate::{id::P2pNode, Prefix, XorName};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -39,25 +39,6 @@ impl EldersInfo {
     /// "field element" which is typically a numeric index.
     pub(crate) fn position(&self, name: &XorName) -> Option<usize> {
         self.elders.keys().position(|other_name| other_name == name)
-    }
-
-    /// Calculate cryptographic hash of this EldersInfo.
-    pub(crate) fn hash(&self) -> Digest256 {
-        use tiny_keccak::{Hasher, Sha3};
-
-        // Calculate the hash without involving serialization to avoid having to return `Result`.
-        let mut hasher = Sha3::v256();
-
-        for name in self.elders.keys() {
-            hasher.update(&name.0);
-        }
-
-        hasher.update(&self.prefix.name().0);
-        hasher.update(&self.prefix.bit_count().to_le_bytes());
-
-        let mut output = Digest256::default();
-        hasher.finalize(&mut output);
-        output
     }
 }
 

--- a/src/section/member_info.rs
+++ b/src/section/member_info.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::id::P2pNode;
+use xor_name::XorName;
 
 /// The minimum age a node can have. The Infants will start at age 4. This is to prevent frequent
 /// relocations during the beginning of a node's lifetime.
@@ -42,6 +43,14 @@ impl MemberInfo {
         }
     }
 
+    // Convert this info into one with the state changed to `Relocated`.
+    pub fn relocate(self, destination: XorName) -> Self {
+        Self {
+            state: MemberState::Relocated(destination),
+            ..self
+        }
+    }
+
     // Converts this info into one with the age increased by one.
     pub fn increment_age(self) -> Self {
         Self {
@@ -53,9 +62,10 @@ impl MemberInfo {
 
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, Debug)]
 pub enum MemberState {
+    // Node is active member of the section.
     Joined,
-    Relocating,
-    // TODO: we should track how long the node has been away. If longer than some limit, remove it
-    // from the list. Otherwise we allow it to return.
+    // Node went offline.
     Left,
+    // Node was relocated to a different section.
+    Relocated(XorName),
 }

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -19,10 +19,8 @@ mod shared_state;
 
 #[cfg(test)]
 pub(crate) use self::elders_info::gen_elders_info;
-#[cfg(feature = "mock")]
-pub use self::elders_info::quorum_count;
 pub use self::{
-    elders_info::EldersInfo,
+    elders_info::{quorum_count, EldersInfo},
     member_info::{MemberInfo, MemberState, MIN_AGE},
     network_stats::NetworkStats,
     section_keys::{SectionKeyShare, SectionKeysProvider},

--- a/src/section/section_keys.rs
+++ b/src/section/section_keys.rs
@@ -59,10 +59,14 @@ impl SectionKeysProvider {
         }
     }
 
-    pub fn finalise_dkg(&mut self) {
-        if let Some(share) = self.pending.take() {
-            trace!("finalise DKG: {:?}", share.public_key_set.public_key());
-            self.current = Some(share);
+    pub fn finalise_dkg(&mut self, public_key: &bls::PublicKey) {
+        if let Some(share) = &self.pending {
+            let pending_public_key = share.public_key_set.public_key();
+
+            if pending_public_key == *public_key {
+                trace!("finalise DKG: {:?}", pending_public_key);
+                self.current = self.pending.take();
+            }
         }
     }
 }

--- a/src/section/section_proof_chain.rs
+++ b/src/section/section_proof_chain.rs
@@ -47,7 +47,8 @@ impl SectionProofChain {
             true
         } else {
             error!(
-                "invalid SectionProofChain block signature (last key: {:?})",
+                "invalid SectionProofChain block signature (new key: {:?}, last key: {:?})",
+                key,
                 self.last_key()
             );
             false

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{EldersInfo, MemberInfo, SectionMap, SectionMembers, SectionProofChain};
+use super::{quorum_count, EldersInfo, MemberInfo, SectionMap, SectionMembers, SectionProofChain};
 use crate::{
     consensus::{Proof, Proven},
     error::Error,
@@ -241,20 +241,11 @@ impl SharedState {
 
         if expected_elders == current_elders {
             vec![]
+        } else if expected_elders.len() < quorum_count(current_elders.len()) {
+            warn!("ignore attempt to reduce the number of elders too much");
+            vec![]
         } else {
             let new_info = EldersInfo::new(expected_elders_map, self.our_info().prefix);
-
-            if new_info.elders.len() < network_params.elder_size
-                && self.our_info().elders.len() >= network_params.elder_size
-            {
-                warn!(
-                    "Dropping below elder_size ({}) elders (old: {:?}, new: {:?})",
-                    network_params.elder_size,
-                    self.our_info(),
-                    new_info
-                );
-            }
-
             vec![new_info]
         }
     }

--- a/src/section/shared_state.rs
+++ b/src/section/shared_state.rs
@@ -149,7 +149,7 @@ impl SharedState {
     /// Returns all nodes we know (our members + neighbour elders).
     pub fn known_nodes(&self) -> impl Iterator<Item = &P2pNode> {
         self.our_members
-            .active()
+            .joined()
             .map(|info| &info.p2p_node)
             .chain(self.sections.neighbour_elders())
     }

--- a/tests/mock_network/accumulate.rs
+++ b/tests/mock_network/accumulate.rs
@@ -9,8 +9,8 @@
 use super::utils::*;
 use rand::Rng;
 use sn_routing::{
-    event::Event, mock::Environment, threshold_count, DstLocation, NetworkParams, Prefix,
-    SrcLocation, XorName,
+    event::Event, mock::Environment, quorum_count, DstLocation, NetworkParams, Prefix, SrcLocation,
+    XorName,
 };
 
 #[test]
@@ -46,9 +46,7 @@ fn messages_accumulate_with_quorum() {
 
     // The BLS scheme will require more than threshold
     // shares in order to construct a full key or signature.
-    // The smallest number such that `quorum > threshold`:
-    let threshold = threshold_count(elder_size);
-    let quorum = 1 + threshold;
+    let quorum = quorum_count(elder_size);
 
     // Send a message from the section `src` to the node `dst`.
     // Only the `quorum`-th sender should cause accumulation and a


### PR DESCRIPTION
This PR refactors and modifies the DKG module with the aim of fixing bugs in it and making it simpler. The new flow goes somehow like this:

1. On every churn, the current elders propose the new elders as the `elder_size` oldest nodes of the section.
2. If the proposed elders are the same as current elders, we are done
3. Otherwise they send `DKGStart` message (signed with their BLS key share) to the proposed elders (also called DKG paricipants)
4.When the `DKGStart` message accumulates, the participant initiates a DKG session and starts exchanging DKG messages with the other participants
5. When the DKG session completes successfully or fails, the participants send `DKGResult` message carrying the result to the current elders
6. The current elders accumulate this message and when they get quorum of results, they action it:
7. If the result is a success, they cast `SectionInfo` and `OurKey` votes to update the section
8. If the result is a failure, they restart the DKG by repeating step 3. 

Unsolved issues:

The above mechanism can sometimes lead to more than one successful DKG outcome (usually during heavy churn). There is currently a simple measure in place which blocks voting for section update if another one is in progress. but it is not completely sufficient because the DKG results can arrive in any order and it can cause section to stall. This is quite rare but still happens and needs to be solved. 
