### PR TITLE
BREAKING CHANGE: API breaking change

### DIFF
--- a/src/section/elders_info.rs
+++ b/src/section/elders_info.rs
@@ -40,7 +40,7 @@ impl EldersInfo {
         self.elders.values()
     }
 
-    /// Returns the index of the elder with `name` in this set of elders.
+    /// Returns the index of the named elder within this set of elders.
     /// This is useful for BLS signatures where the signature share needs to be mapped to a
     /// "field element" which is typically a numeric index.
     pub(crate) fn position(&self, name: &XorName) -> Option<usize> {


### PR DESCRIPTION
This commit is to mark the previous API changes of:
1, Node got renamed to Routing
2, NodeConfig renamed to Config