### PR TITLE
fix: no longer use serde macro derive

### DIFF
--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -15,6 +15,7 @@ use crate::{
 use bls_dkg::key_gen::{outcome::Outcome, KeyGen};
 use hex_fmt::HexFmt;
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Debug, Formatter},

--- a/src/consensus/proven.rs
+++ b/src/consensus/proven.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{consensus::Proof, section::SectionProofChain};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{borrow::Borrow, fmt::Debug};
 use xor_name::Prefix;
 

--- a/src/consensus/vote.rs
+++ b/src/consensus/vote.rs
@@ -12,7 +12,7 @@ use crate::{
     messages::PlainMessage,
     section::{EldersInfo, MemberInfo, SectionProofChain},
 };
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use xor_name::{Prefix, XorName};
 
 #[derive(Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,6 @@
 
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate serde;
 
 // ############################################################################
 // Public API

--- a/src/location.rs
+++ b/src/location.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::error::{Error, Result};
+use serde::{Deserialize, Serialize};
 use xor_name::{Prefix, XorName};
 
 /// Message source location.

--- a/src/messages/hash.rs
+++ b/src/messages/hash.rs
@@ -8,6 +8,7 @@
 
 use crate::crypto::{self, Digest256};
 use hex_fmt::HexFmt;
+use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Formatter};
 
 /// Cryptographic hash of Message

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -25,6 +25,7 @@ use crate::{
 
 use bytes::Bytes;
 use err_derive::Error;
+use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Formatter};
 use xor_name::Prefix;
 

--- a/src/messages/plain_message.rs
+++ b/src/messages/plain_message.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{DstLocation, SignableView, Variant};
+use serde::{Deserialize, Serialize};
 use xor_name::Prefix;
 
 /// Section-source message without signature and proof.

--- a/src/messages/src_authority.rs
+++ b/src/messages/src_authority.rs
@@ -12,7 +12,7 @@ use crate::{
     location::SrcLocation,
     peer::Peer,
 };
-
+use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use xor_name::{Prefix, XorName};
 

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use bytes::Bytes;
 use hex_fmt::HexFmt;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Debug, Formatter},
     net::SocketAddr,

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     section::{EldersInfo, SectionProofChain},
 };
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, iter};
 use xor_name::{Prefix, XorName};
 

--- a/src/network/prefix_map.rs
+++ b/src/network/prefix_map.rs
@@ -6,6 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use serde::{Deserialize, Serialize};
 use std::{
     borrow::Borrow,
     cmp::Ordering,

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     fmt::{self, Display, Formatter},
     hash::Hash,

--- a/src/section/member_info.rs
+++ b/src/section/member_info.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::peer::Peer;
+use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
 /// The minimum age a node can have. The Infants will start at age 4. This is to prevent frequent

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     rng, NetworkParams,
 };
 use bls_signature_aggregator::Proof;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},

--- a/src/section/section_peers.rs
+++ b/src/section/section_peers.rs
@@ -13,6 +13,7 @@ use super::{
 use crate::{consensus::Proven, peer::Peer};
 
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
     collections::{

--- a/src/section/section_proof_chain.rs
+++ b/src/section/section_proof_chain.rs
@@ -7,6 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use err_derive::Error;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
     iter, mem,


### PR DESCRIPTION
switching to the formal setup as stated at https://serde.rs/derive.html