### PR TITLE
Proptest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,5 @@ anyhow = "1"
 assert_matches = "1.3"
 env_logger = "~0.7.1"
 structopt = "~0.3.17"
+proptest = "0.10.1"
 

--- a/proptest-regressions/lib.txt
+++ b/proptest-regressions/lib.txt
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc ef9c8aacd1f45c12765af4b80046d95f5b55bbdbb6448914e8e9efc241f6bf88 # shrinks to a = 0
+cc 5663142721d97e09e5c273a737e1779e83c6f6c8ab07e5dc305ae6bde19c7fc6 # shrinks to a = 464
+cc ff6fc79726eabc4c36a2016e322ca2fa624250a6b2d04b6b31d7822acf9a7520 # shrinks to a = 3
+cc aeb57950b6ad1667b5891467bb2213d90cdd78258ced00d8cccceef2053df401 # shrinks to a = 0

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -6,7 +6,13 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{crypto::Digest256, peer::Peer, majority, rng::{self, MainRng}, section::EldersInfo};
+use crate::{
+    crypto::Digest256,
+    majority,
+    peer::Peer,
+    rng::{self, MainRng},
+    section::EldersInfo,
+};
 use bls_dkg::key_gen::{outcome::Outcome, KeyGen};
 use hex_fmt::HexFmt;
 use itertools::Itertools;

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -6,12 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{
-    crypto::Digest256,
-    peer::Peer,
-    rng::{self, MainRng},
-    section::{majority_count, EldersInfo},
-};
+use crate::{crypto::Digest256, peer::Peer, majority, rng::{self, MainRng}, section::EldersInfo};
 use bls_dkg::key_gen::{outcome::Outcome, KeyGen};
 use hex_fmt::HexFmt;
 use itertools::Itertools;
@@ -110,7 +105,7 @@ impl DkgVoter {
             }
         }
 
-        let threshold = majority_count(elders_info.elders.len()) - 1;
+        let threshold = majority(elders_info.elders.len()) - 1;
         let participants = elders_info
             .elders
             .values()
@@ -287,7 +282,7 @@ impl DkgVoter {
 
         let total: usize = session.accumulator.values().map(|ids| ids.len()).sum();
         let missing = session.elders_info.elders.len() - total;
-        let majority = majority_count(session.elders_info.elders.len());
+        let majority = majority(session.elders_info.elders.len());
 
         let result = if let Some((public_key, count)) = session
             .accumulator

--- a/src/delivery_group.rs
+++ b/src/delivery_group.rs
@@ -8,11 +8,17 @@
 
 //! Utilities for sn_routing messages through the network.
 
-use crate::{ELDER_MAJORITY, error::{Error, Result}, location::DstLocation, network::Network, peer::Peer, section::Section};
-use std::{cmp, iter};
+use crate::{
+    error::{Error, Result},
+    location::DstLocation,
+    network::Network,
+    peer::Peer,
+    section::Section,
+    ELDER_MAJORITY,
+};
 use itertools::Itertools;
+use std::{cmp, iter};
 use xor_name::XorName;
-
 
 /// Returns a set of nodes to which a message for the given `DstLocation` could be sent
 /// onwards, sorted by priority, along with the number of targets the message should be sent to.
@@ -100,9 +106,14 @@ fn candidates(
     for (idx, (prefix, len, connected)) in sections.enumerate() {
         nodes_to_send.extend(connected.cloned());
         // If we don't have enough contacts send to as many as possible
-        // up to majority of Elders 
+        // up to majority of Elders
         dg_size = cmp::min(len, dg_size);
-        if len < ELDER_MAJORITY { warn!("Delivery group only {:?} when it should be {:?}", len, ELDER_MAJORITY)}
+        if len < ELDER_MAJORITY {
+            warn!(
+                "Delivery group only {:?} when it should be {:?}",
+                len, ELDER_MAJORITY
+            )
+        }
 
         if prefix == section.prefix() {
             // Send to all connected targets so they can forward the message

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,14 +126,19 @@ pub(crate) fn majority(num_possible_voters: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use crate::{ELDER_MAJORITY, ELDER_SIZE};
+    use proptest::prelude::*;
 
     use super::majority;
-
+    proptest! {
+        #[test]
+        fn pt_strict_majority(a in any::<usize>()) {
+            let maj = majority(a);
+            let maj_double = maj * 2;
+            assert!(maj_double == a || maj_double == a + 1 || maj_double == a + 2);
+        }
+    }
     #[test]
-    fn strict_majority() {
-        assert_eq!(majority(4), majority(5));
-        assert_eq!(majority(6), majority(7));
-        assert_eq!(majority(7), 4);
+    fn strict_majority_from_consts() {
         assert_eq!(ELDER_MAJORITY, majority(ELDER_SIZE))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,13 +107,6 @@ mod section;
 // Cryptography
 mod crypto;
 
-/// Majority is defined as having strictly greater than `MAJORITY_NUMERATOR / MAJORITY_DENOMINATOR`
-/// agreement; using only integer arithmetic a quorum can be checked with
-/// `votes * MAJORITY_DENOMINATOR > voters * MAJORITY_NUMERATOR`.
-const MAJORITY_NUMERATOR: usize = 2;
-/// See `QUORUM_NUMERATOR`.
-const MAJORITY_DENOMINATOR: usize = 3;
-
 /// Recommended section size. sn_routing will keep adding nodes until the section reaches this size.
 /// More nodes might be added if requested by the upper layers.
 /// This number also detemines when split happens - if both post-split sections would have at least
@@ -122,21 +115,27 @@ const RECOMMENDED_SECTION_SIZE: usize = 60;
 
 /// Number of elders per section.
 const ELDER_SIZE: usize = 7;
+/// Strict majority of Elders
+const ELDER_MAJORITY: usize = 4;
 
+/// Number of votes required to agree 
+/// with a strict majority (i.e. > 50%)
+pub(crate) fn majority(num_possible_voters: usize) -> usize {
+    1 + (num_possible_voters /2) 
+}
 #[cfg(test)]
 mod tests {
-    use super::{MAJORITY_DENOMINATOR, MAJORITY_NUMERATOR};
+        use crate::{ELDER_MAJORITY, ELDER_SIZE};
+
+use super::majority;
 
     #[test]
-    #[allow(clippy::assertions_on_constants)]
-    fn quorum_check() {
-        assert!(
-            MAJORITY_NUMERATOR < MAJORITY_DENOMINATOR,
-            "Majority impossible to achieve"
-        );
-        assert!(
-            MAJORITY_NUMERATOR * 2 >= MAJORITY_DENOMINATOR,
-            "Majority does not guarantee agreement"
-        );
-    }
+    fn strict_majority() {
+        assert_eq!(majority(4), majority(5));
+        assert_eq!(majority(6), majority(7));
+        assert_eq!(majority(7), 4);
+        assert_eq!(ELDER_MAJORITY, majority(ELDER_SIZE))
+
 }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,16 +118,16 @@ const ELDER_SIZE: usize = 7;
 /// Strict majority of Elders
 const ELDER_MAJORITY: usize = 4;
 
-/// Number of votes required to agree 
+/// Number of votes required to agree
 /// with a strict majority (i.e. > 50%)
 pub(crate) fn majority(num_possible_voters: usize) -> usize {
-    1 + (num_possible_voters /2) 
+    1 + (num_possible_voters / 2)
 }
 #[cfg(test)]
 mod tests {
-        use crate::{ELDER_MAJORITY, ELDER_SIZE};
+    use crate::{ELDER_MAJORITY, ELDER_SIZE};
 
-use super::majority;
+    use super::majority;
 
     #[test]
     fn strict_majority() {
@@ -135,7 +135,5 @@ use super::majority;
         assert_eq!(majority(6), majority(7));
         assert_eq!(majority(7), 4);
         assert_eq!(ELDER_MAJORITY, majority(ELDER_SIZE))
-
+    }
 }
-}
-

--- a/src/routing/tests/mod.rs
+++ b/src/routing/tests/mod.rs
@@ -7,22 +7,10 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Approved, Comm, Command, Stage};
-use crate::{
-    consensus::{test_utils::*, Proven, Vote},
-    crypto,
-    event::Event,
-    location::DstLocation,
-    messages::{BootstrapResponse, JoinRequest, Message, PlainMessage, Variant},
-    network::Network,
-    node::Node,
-    peer::Peer,
-    rng,
-    section::{
-        majority_count, test_utils::*, EldersInfo, MemberInfo, PeerState, Section, SectionKeyShare,
+use crate::{ELDER_SIZE, Error, NetworkParams, consensus::{test_utils::*, Proven, Vote}, crypto, event::Event, location::DstLocation, ELDER_MAJORITY, messages::{BootstrapResponse, JoinRequest, Message, PlainMessage, Variant}, network::Network, node::Node, peer::Peer, rng, section::{
+        test_utils::*, EldersInfo, MemberInfo, PeerState, Section, SectionKeyShare,
         SectionProofChain, MIN_AGE,
-    },
-    Error, NetworkParams, ELDER_SIZE,
-};
+    }};
 use anyhow::Result;
 use assert_matches::assert_matches;
 use bytes::Bytes;
@@ -1083,7 +1071,7 @@ async fn receive_message_with_invalid_proof_chain() -> Result<()> {
 
 // TODO: add more tests here
 
-const THRESHOLD: usize = majority_count(ELDER_SIZE) - 1;
+const THRESHOLD: usize = ELDER_MAJORITY - 1;
 
 fn create_keypair() -> Keypair {
     let mut rng = rng::new();

--- a/src/routing/tests/mod.rs
+++ b/src/routing/tests/mod.rs
@@ -7,10 +7,22 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Approved, Comm, Command, Stage};
-use crate::{ELDER_SIZE, Error, NetworkParams, consensus::{test_utils::*, Proven, Vote}, crypto, event::Event, location::DstLocation, ELDER_MAJORITY, messages::{BootstrapResponse, JoinRequest, Message, PlainMessage, Variant}, network::Network, node::Node, peer::Peer, rng, section::{
+use crate::{
+    consensus::{test_utils::*, Proven, Vote},
+    crypto,
+    event::Event,
+    location::DstLocation,
+    messages::{BootstrapResponse, JoinRequest, Message, PlainMessage, Variant},
+    network::Network,
+    node::Node,
+    peer::Peer,
+    rng,
+    section::{
         test_utils::*, EldersInfo, MemberInfo, PeerState, Section, SectionKeyShare,
         SectionProofChain, MIN_AGE,
-    }};
+    },
+    Error, NetworkParams, ELDER_MAJORITY, ELDER_SIZE,
+};
 use anyhow::Result;
 use assert_matches::assert_matches;
 use bytes::Bytes;

--- a/src/section/elders_info.rs
+++ b/src/section/elders_info.rs
@@ -74,14 +74,6 @@ impl Display for EldersInfo {
     }
 }
 
-/// Returns the number of vote for a majority of this section such that:
-/// majority_count * MAJORITY_DENOMINATOR > elder_size * MAJORITY_NUMERATOR
-#[inline]
-pub const fn majority_count(elder_size: usize) -> usize {
-    use crate::{MAJORITY_DENOMINATOR, MAJORITY_NUMERATOR};
-    1 + (elder_size * MAJORITY_NUMERATOR) / MAJORITY_DENOMINATOR
-}
-
 #[cfg(test)]
 pub(crate) mod test_utils {
     use super::EldersInfo;

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -16,7 +16,7 @@ mod section_proof_chain;
 pub(crate) use self::elders_info::test_utils;
 pub(crate) use self::section_peers::SectionPeers;
 pub use self::{
-    elders_info::{majority_count, EldersInfo},
+    elders_info::EldersInfo,
     member_info::{MemberInfo, PeerState, MIN_AGE},
     section_keys::{SectionKeyShare, SectionKeysProvider},
     section_proof_chain::{ExtendError, SectionProofChain, TrustStatus},
@@ -216,7 +216,7 @@ impl Section {
 
         if expected_elders == current_elders {
             vec![]
-        } else if expected_elders.len() < majority_count(current_elders.len()) {
+        } else if expected_elders.len() < crate::majority(current_elders.len()) {
             warn!("ignore attempt to reduce the number of elders too much");
             vec![]
         } else {


### PR DESCRIPTION
Use proptest. This PR introduces protest with a very simple strategy used (<any>::usize()) Hopefully this paves the way for a stronger test suite and helps find edge cases. 

An interesting thing in this test is 
`assert!(maj_double == a || maj_double == a + 1 || maj_double == a + 2);`
why the `maj_double == a + 2`?  it seems to make no sence. So change the line to 
`assert!(maj_double == a || maj_double == a + 1 );`
And see the result, plus also see shrink/complex() methods id use. 
Ad a line just above this like 
`dbg!(a, maj, maj_double);` to help visualise what's happening here. 