### PR TITLE
Extract most of the DKG logic out of Approved and into DkgVoter + adds some DKG tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -121,13 +121,15 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+        # TODO: temporarily disable cache on macos due to weird issues. Needs further investigation.
+        if: matrix.os != 'macOS-latest'
 
       # Run tests.
       - shell: bash
         run: ./scripts/tests
 
       # Print CI machine disk space stats if the tests fail
-      - name: Print CI Machine df Stats on Failure 
+      - name: Print CI Machine df Stats on Failure
         if: failure()
         run: df -Ph
         shell: bash

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -10,8 +10,7 @@ use crate::{
     crypto::Digest256,
     error::Result,
     majority,
-    messages::Message,
-    messages::Variant,
+    messages::{Message, Variant},
     node::Node,
     peer::Peer,
     routing::command::{self, Command},
@@ -422,16 +421,12 @@ impl Participant {
     }
 
     fn check(&mut self) -> Option<Command> {
-        let _ = self.elders_info.as_ref()?;
-
         if !self.key_gen.is_finalized() {
             return None;
         }
 
         let (participants, outcome) = self.key_gen.generate_keys()?;
-
-        // This is OK to `unwrap` because we already checked it is `Some`.
-        let elders_info = self.elders_info.take().unwrap();
+        let elders_info = self.elders_info.take()?;
 
         if participants.iter().eq(elders_info.elders.keys()) {
             trace!(

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -6,18 +6,31 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::{crypto::Digest256, majority, peer::Peer, section::EldersInfo};
-use bls_dkg::key_gen::{outcome::Outcome, KeyGen};
+use crate::{
+    crypto::Digest256,
+    error::Result,
+    majority,
+    messages::Message,
+    messages::Variant,
+    node::Node,
+    peer::Peer,
+    routing::command::{self, Command},
+    section::EldersInfo,
+    DstLocation,
+};
+use bls_dkg::key_gen::{message::Message as DkgMessage, KeyGen};
 use hex_fmt::HexFmt;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Debug, Formatter},
+    time::Duration,
 };
 use xor_name::XorName;
 
-pub type DkgMessage = bls_dkg::key_gen::message::Message;
+// Interval to progress DKG timed phase
+const DKG_PROGRESS_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Unique identified of a DKG session.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
@@ -61,9 +74,7 @@ impl Debug for DkgKey {
 ///    new elders candidates (DKG participants) and also call `start_observing` to initialize the
 ///    DKG result accumulator.
 /// 3. When the `DKGStart` message accumulates, the participants call `start_participating`.
-/// 4. The participants keep exchanging the DKG messages and calling `process_dkg_message`.
-/// 5. The participants call `check_dkg` to check whether the DKG session completed or failed.
-/// 6. They should also run a timer in case of inactivity and call `progress_dkg` when it fires.
+/// 4. The participants keep exchanging the DKG messages and calling `process_message`.
 /// 7. On DKG completion or failure, the participants send `DKGResult` message to the current
 ///    elders (observers)
 /// 8. The observers call `observe_result` with each received `DKGResult`.
@@ -74,7 +85,7 @@ impl Debug for DkgKey {
 /// Note: in case of heavy churn, it can happen that more than one DKG session completes
 /// successfully. Some kind of disambiguation strategy needs to be employed in that case, but that
 /// is currently not a responsibility of this module.
-pub struct DkgVoter {
+pub(crate) struct DkgVoter {
     participant: Option<Participant>,
     observers: HashMap<DkgKey, Observer>,
 }
@@ -89,18 +100,17 @@ impl Default for DkgVoter {
 }
 
 impl DkgVoter {
-    // Starts a new DKG session as a participant. The caller should broadcast the returned messages
-    // to the other DKG participants.
+    // Starts a new DKG session as a participant.
     pub fn start_participating(
         &mut self,
-        our_name: XorName,
+        node: &Node,
         dkg_key: DkgKey,
         elders_info: EldersInfo,
-    ) -> Option<DkgMessage> {
+    ) -> Result<Vec<Command>> {
         if let Some(session) = &self.participant {
             if session.dkg_key == dkg_key && session.elders_info.is_some() {
                 trace!("DKG for {} already in progress", elders_info);
-                return None;
+                return Ok(vec![]);
             }
         }
 
@@ -112,23 +122,33 @@ impl DkgVoter {
             .copied()
             .collect();
 
-        match KeyGen::initialize(our_name, threshold, participants) {
+        match KeyGen::initialize(node.name(), threshold, participants) {
             Ok((key_gen, message)) => {
                 trace!("DKG for {} starting", elders_info);
 
-                self.participant = Some(Participant {
+                let mut session = Participant {
                     dkg_key,
                     key_gen,
                     elders_info: Some(elders_info),
                     timer_token: 0,
-                });
+                };
 
-                Some(message)
+                let mut commands = session.broadcast(node, dkg_key, message)?;
+
+                if let Some(command) = session.check() {
+                    // Already completed.
+                    commands.push(command)
+                } else {
+                    commands.push(session.reset_timer());
+                    self.participant = Some(session);
+                }
+
+                Ok(commands)
             }
             Err(error) => {
-                debug!("DKG for {} failed to start: {}", elders_info, error);
-
-                None
+                // TODO: return error here
+                error!("DKG for {} failed to start: {}", elders_info, error);
+                Ok(vec![])
             }
         }
     }
@@ -149,62 +169,25 @@ impl DkgVoter {
         });
     }
 
-    // Check whether a key generator is finalized to give a DKG outcome.
-    //
-    // Returns:
-    // - `Some(Ok((elders_info, outcome)))` if the DKG successfully completed
-    // - `Some(Err(elders_info))` if the DKG failed
-    // - `None` if the DKG is still in progress or if there is no active DKG session.
-    //
-    // A returned `Some` should be sent to the DKG observers for accumulation.
-    pub fn check_dkg(&mut self) -> Option<Result<(EldersInfo, Outcome), ()>> {
-        let session = self.participant.as_mut()?;
-        let _ = session.elders_info.as_ref()?;
-
-        if !session.key_gen.is_finalized() {
-            return None;
-        }
-
-        let (participants, outcome) = session.key_gen.generate_keys()?;
-
-        // This is OK to `unwrap` because we already checked it is `Some`.
-        let elders_info = session.elders_info.take().unwrap();
-
-        if participants.iter().eq(elders_info.elders.keys()) {
-            trace!(
-                "DKG for {} complete: {:?}",
-                elders_info,
-                outcome.public_key_set.public_key()
-            );
-
-            // Note: we keep `self.participant` set because other nodes might still need to receive
-            // DKG messages from us for them to complete.
-
-            Some(Ok((elders_info, outcome)))
-        } else {
-            trace!(
-                "DKG for {} failed: unexpected participants: {:?}",
-                elders_info,
-                participants.iter().format(", ")
-            );
-
-            self.participant = None;
-
-            Some(Err(()))
-        }
-    }
-
     // Make key generator progress with timed phase.
-    //
-    // Returns:
-    // - `Some((dkg_key, Ok(messages)))` if the DKG is still in progress. The returned messages
-    //   should be broadcast to the other participants.
-    // - `Some((dkg_key, Err(())))` if the DKG failed. The result should be sent to the DKG observers
-    //   for accumulation.
-    // - `None` if there is no active DKG session.
-    pub fn progress_dkg(&mut self) -> Option<(DkgKey, Result<Vec<DkgMessage>, ()>)> {
-        let session = self.participant.as_mut()?;
-        let elders_info = session.elders_info.as_ref()?;
+    pub fn handle_timeout(&mut self, node: &Node, timer_token: u64) -> Result<Vec<Command>> {
+        let session = if let Some(session) = self.participant.as_mut() {
+            session
+        } else {
+            return Ok(vec![]);
+        };
+
+        if session.timer_token != timer_token {
+            return Ok(vec![]);
+        }
+
+        let elders_info = if let Some(elders_info) = session.elders_info.as_ref() {
+            elders_info
+        } else {
+            return Ok(vec![]);
+        };
+
+        let dkg_key = session.dkg_key;
 
         trace!("DKG for {} progressing", elders_info);
 
@@ -212,61 +195,65 @@ impl DkgVoter {
             .key_gen
             .timed_phase_transition(&mut rand::thread_rng())
         {
-            Ok(messages) => Some((session.dkg_key, Ok(messages))),
+            Ok(messages) => {
+                let mut commands = vec![];
+
+                for message in messages {
+                    commands.extend(session.broadcast(node, dkg_key, message)?);
+                }
+                commands.push(session.reset_timer());
+                commands.extend(self.check());
+
+                Ok(commands)
+            }
             Err(error) => {
                 trace!("DKG for {} failed: {}", elders_info, error);
 
-                let dkg_key = session.dkg_key;
+                let elders_info = session.elders_info.take().unwrap();
+
                 self.participant = None;
 
-                Some((dkg_key, Err(())))
+                Ok(vec![Command::HandleDkgParticipationResult {
+                    dkg_key,
+                    elders_info,
+                    result: Err(()),
+                }])
             }
         }
     }
 
-    /// Returns the participants of the DKG session, if there is one.
-    pub fn participants(&self) -> impl Iterator<Item = &Peer> {
-        self.participant
-            .as_ref()
-            .and_then(|session| session.elders_info.as_ref())
-            .into_iter()
-            .flat_map(|elders_info| elders_info.elders.values())
-    }
-
-    // Handle a received DkgMessage. Returns with DkgMessages to broadcast to the other
-    // participants, if any.
-    pub fn process_dkg_message(
+    // Handle a received DkgMessage.
+    pub fn process_message(
         &mut self,
-        dkg_key: &DkgKey,
+        node: &Node,
+        dkg_key: DkgKey,
         message: DkgMessage,
-    ) -> Vec<DkgMessage> {
+    ) -> Result<Vec<Command>> {
         let session = if let Some(session) = &mut self.participant {
             session
         } else {
-            return vec![];
+            return Ok(vec![]);
         };
 
-        if session.dkg_key != *dkg_key {
-            return vec![];
+        let mut commands = session.process_message(node, dkg_key, message)?;
+
+        // Only a valid DkgMessage, which results in some responses, shall reset the ticker.
+        if !commands.is_empty() {
+            commands.push(session.reset_timer());
         }
 
-        session
-            .key_gen
-            .handle_message(&mut rand::thread_rng(), message)
-            .unwrap_or_default()
+        commands.extend(self.check());
+
+        Ok(commands)
     }
 
-    // Observer and accumulate a DKG result (either success or failure).
-    //
-    // Returns:
-    // - `Some((EldersInfo, Result))` if the results accumulated
-    // - `None` if more results are still needed
+    // Observe and accumulate a DKG result (either success or failure).
     pub fn observe_result(
         &mut self,
         dkg_key: &DkgKey,
         result: Result<bls::PublicKey, ()>,
         sender: XorName,
-    ) -> Option<(EldersInfo, Result<bls::PublicKey, ()>)> {
+    ) -> Option<Command> {
         let session = self.observers.get_mut(dkg_key)?;
 
         if !session.elders_info.elders.contains_key(&sender) {
@@ -325,26 +312,15 @@ impl DkgVoter {
             session.elders_info.clone()
         };
 
-        Some((elders_info, result))
+        Some(Command::HandleDkgObservationResult {
+            elders_info,
+            result,
+        })
     }
 
     pub fn stop_observing(&mut self, section_key_index: u64) {
         self.observers
             .retain(|_, session| session.section_key_index >= section_key_index);
-    }
-
-    // Returns the timer token of the active DKG session if there is one. If this timer fires, we
-    // should call `progress_dkg`.
-    pub fn timer_token(&self) -> Option<u64> {
-        self.participant.as_ref().map(|session| session.timer_token)
-    }
-
-    // Sets the timer token for the active DKG session. This should be set after a successful DKG
-    // initialization, or after handling a DKG message that produced at least one response.
-    pub fn set_timer_token(&mut self, token: u64) {
-        if let Some(session) = &mut self.participant {
-            session.timer_token = token;
-        }
     }
 
     // Is this node participating in any DKG session?
@@ -357,6 +333,20 @@ impl DkgVoter {
             .get(dkg_key)
             .map(|session| &session.elders_info)
     }
+
+    // Check whether a key generator is finalized to give a DKG outcome.
+    fn check(&mut self) -> Option<Command> {
+        let session = self.participant.as_mut()?;
+        let command = session.check()?;
+
+        // NOTE: Only reset `self.participant` on failed completion, because on success other nodes
+        // might still need to receive DKG messages from us.
+        if matches!(command, Command::HandleDkgParticipationResult { result: Err(()), .. }) {
+            self.participant = None
+        }
+
+        Some(command)
+    }
 }
 
 // Data for a DKG participant.
@@ -366,6 +356,117 @@ struct Participant {
     dkg_key: DkgKey,
     key_gen: KeyGen,
     timer_token: u64,
+}
+
+impl Participant {
+    fn process_message(
+        &mut self,
+        node: &Node,
+        dkg_key: DkgKey,
+        message: DkgMessage,
+    ) -> Result<Vec<Command>> {
+        if self.dkg_key != dkg_key {
+            return Ok(vec![]);
+        }
+
+        let responses = self
+            .key_gen
+            .handle_message(&mut rand::thread_rng(), message)
+            .unwrap_or_default();
+
+        let mut commands = vec![];
+        for response in responses {
+            commands.extend(self.broadcast(node, dkg_key, response)?);
+        }
+
+        Ok(commands)
+    }
+
+    fn broadcast(
+        &mut self,
+        node: &Node,
+        dkg_key: DkgKey,
+        dkg_message: DkgMessage,
+    ) -> Result<Vec<Command>> {
+        let recipients: Vec<_> = self
+            .elders_info
+            .as_ref()
+            .into_iter()
+            .flat_map(EldersInfo::peers)
+            .filter(|peer| *peer.name() != node.name())
+            .map(Peer::addr)
+            .copied()
+            .collect();
+
+        trace!(
+            "broadcasting DKG message {:?} to {:?}",
+            dkg_message,
+            recipients
+        );
+
+        let variant = Variant::DKGMessage {
+            dkg_key,
+            message: bincode::serialize(&dkg_message)?.into(),
+        };
+        let message = Message::single_src(node, DstLocation::Direct, variant, None, None)?;
+
+        let mut commands = vec![];
+        commands.push(Command::send_message_to_targets(
+            &recipients,
+            recipients.len(),
+            message.to_bytes(),
+        ));
+        commands.extend(self.process_message(node, dkg_key, dkg_message)?);
+
+        Ok(commands)
+    }
+
+    fn check(&mut self) -> Option<Command> {
+        let _ = self.elders_info.as_ref()?;
+
+        if !self.key_gen.is_finalized() {
+            return None;
+        }
+
+        let (participants, outcome) = self.key_gen.generate_keys()?;
+
+        // This is OK to `unwrap` because we already checked it is `Some`.
+        let elders_info = self.elders_info.take().unwrap();
+
+        if participants.iter().eq(elders_info.elders.keys()) {
+            trace!(
+                "DKG for {} complete: {:?}",
+                elders_info,
+                outcome.public_key_set.public_key()
+            );
+
+            Some(Command::HandleDkgParticipationResult {
+                dkg_key: self.dkg_key,
+                elders_info,
+                result: Ok(outcome),
+            })
+        } else {
+            trace!(
+                "DKG for {} failed: unexpected participants: {:?}",
+                elders_info,
+                participants.iter().format(", ")
+            );
+
+            Some(Command::HandleDkgParticipationResult {
+                dkg_key: self.dkg_key,
+                elders_info,
+                result: Err(()),
+            })
+        }
+    }
+
+    fn reset_timer(&mut self) -> Command {
+        self.timer_token = command::next_timer_token();
+        Command::ScheduleTimeout {
+            duration: DKG_PROGRESS_INTERVAL,
+            token: self.timer_token,
+        }
+    }
 }
 
 // Data for a DKG observer.

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -12,9 +12,9 @@ mod proven;
 pub mod test_utils;
 mod vote;
 
-pub(crate) use self::vote::{Vote, VoteAccumulator};
-pub use self::{
-    dkg::{DkgKey, DkgVoter},
-    proven::Proven,
+pub use self::{dkg::DkgKey, proven::Proven};
+pub(crate) use self::{
+    dkg::DkgVoter,
+    vote::{Vote, VoteAccumulator},
 };
 pub use bls_signature_aggregator::{AccumulationError, Proof, ProofShare, SignatureAggregator};

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{command, Command, UpdateBarrier};
+use super::{Command, UpdateBarrier};
 use crate::{
     consensus::{
         AccumulationError, DkgKey, DkgVoter, Proof, ProofShare, Proven, Vote, VoteAccumulator,
@@ -33,15 +33,12 @@ use crate::{
     },
     NetworkParams,
 };
-use bls_dkg::key_gen::message::Message as DkgMessage;
+use bls_dkg::key_gen::outcome::Outcome as DkgOutcome;
 use bytes::Bytes;
 use itertools::Itertools;
-use std::{net::SocketAddr, slice, time::Duration};
+use std::{net::SocketAddr, slice};
 use tokio::sync::mpsc;
 use xor_name::{Prefix, XorName};
-
-// Interval to progress DKG timed phase
-const DKG_PROGRESS_INTERVAL: Duration = Duration::from_secs(30);
 
 // The approved stage - node is a full member of a section and is performing its duties according
 // to its persona (infant, adult or elder).
@@ -169,20 +166,7 @@ impl Approved {
     }
 
     pub fn handle_timeout(&mut self, token: u64) -> Result<Vec<Command>> {
-        let mut commands = Vec::new();
-
-        if self.dkg_voter.timer_token() == Some(token) {
-            let token = command::next_timer_token();
-            self.dkg_voter.set_timer_token(token);
-
-            commands.push(Command::ScheduleTimeout {
-                duration: DKG_PROGRESS_INTERVAL,
-                token,
-            });
-            commands.extend(self.progress_dkg()?);
-        }
-
-        Ok(commands)
+        self.dkg_voter.handle_timeout(&self.node, token)
     }
 
     // Insert the vote into the vote accumulator and handle it if accumulated.
@@ -248,6 +232,72 @@ impl Approved {
         } else {
             Ok(vec![])
         }
+    }
+
+    pub fn handle_dkg_participation_result(
+        &mut self,
+        dkg_key: DkgKey,
+        elders_info: EldersInfo,
+        result: Result<DkgOutcome, ()>,
+    ) -> Result<Vec<Command>> {
+        let key = result
+            .as_ref()
+            .map(|outcome| outcome.public_key_set.public_key())
+            .map_err(|_| ());
+
+        if let Ok(outcome) = result {
+            self.section_keys_provider
+                .insert_dkg_outcome(&self.node.name(), &elders_info, outcome);
+        }
+
+        let mut commands = vec![];
+        commands.push(self.send_dkg_result(dkg_key, key)?);
+        commands.extend(self.handle_dkg_result(dkg_key, key, self.node.name()));
+
+        Ok(commands)
+    }
+
+    pub fn handle_dkg_observation_result(
+        &mut self,
+        dkg_elders_info: EldersInfo,
+        result: Result<bls::PublicKey, ()>,
+    ) -> Result<Vec<Command>> {
+        trace!(
+            "accumulated DKG result for {}: {:?}",
+            dkg_elders_info,
+            result
+        );
+
+        let mut commands = vec![];
+
+        for new_elders_info in self
+            .section
+            .promote_and_demote_elders(&self.network_params, &self.node.name())
+        {
+            // Check whether the result still corresponds to the current elder candidates.
+            if new_elders_info == dkg_elders_info {
+                debug!("handle DKG result for {}: {:?}", new_elders_info, result);
+
+                if let Ok(public_key) = result {
+                    commands.extend(self.vote_for_section_update(public_key, new_elders_info)?);
+                } else {
+                    commands.extend(self.send_dkg_start(new_elders_info)?);
+                }
+            } else if new_elders_info.prefix == dkg_elders_info.prefix
+                || new_elders_info
+                    .prefix
+                    .is_extension_of(&dkg_elders_info.prefix)
+            {
+                trace!(
+                    "ignore DKG result for {}: {:?} - outdated",
+                    dkg_elders_info,
+                    result
+                );
+                commands.extend(self.send_dkg_start(new_elders_info)?);
+            }
+        }
+
+        Ok(commands)
     }
 
     // Send vote to all our elders.
@@ -337,42 +387,6 @@ impl Approved {
         } else {
             Ok(None)
         }
-    }
-
-    fn check_dkg(&mut self, dkg_key: DkgKey) -> Result<Vec<Command>> {
-        match self.dkg_voter.check_dkg() {
-            Some(Ok((elders_info, outcome))) => {
-                let public_key = outcome.public_key_set.public_key();
-                self.section_keys_provider.insert_dkg_outcome(
-                    &self.node.name(),
-                    &elders_info,
-                    outcome,
-                );
-                self.handle_dkg_result(dkg_key, Ok(public_key), self.node.name())
-            }
-            Some(Err(())) => self.handle_dkg_result(dkg_key, Err(()), self.node.name()),
-            None => Ok(vec![]),
-        }
-    }
-
-    fn progress_dkg(&mut self) -> Result<Vec<Command>> {
-        let mut commands = vec![];
-
-        match self.dkg_voter.progress_dkg() {
-            Some((dkg_key, Ok(messages))) => {
-                for message in messages {
-                    commands.extend(self.broadcast_dkg_message(dkg_key, message)?);
-                }
-
-                commands.extend(self.check_dkg(dkg_key)?)
-            }
-            Some((dkg_key, Err(()))) => {
-                commands.extend(self.handle_dkg_result(dkg_key, Err(()), self.node.name())?)
-            }
-            None => {}
-        }
-
-        Ok(commands)
     }
 
     /// Is this node an elder?
@@ -527,9 +541,10 @@ impl Approved {
             Variant::DKGMessage { dkg_key, message } => {
                 self.handle_dkg_message(*dkg_key, message.clone(), msg.src().to_node_name()?)
             }
-            Variant::DKGResult { dkg_key, result } => {
-                self.handle_dkg_result(*dkg_key, *result, msg.src().to_node_name()?)
-            }
+            Variant::DKGResult { dkg_key, result } => Ok(self
+                .handle_dkg_result(*dkg_key, *result, msg.src().to_node_name()?)
+                .into_iter()
+                .collect()),
             Variant::Vote {
                 content,
                 proof_share,
@@ -1044,24 +1059,8 @@ impl Approved {
         new_elders_info: EldersInfo,
     ) -> Result<Vec<Command>> {
         trace!("Received DKGStart for {}", new_elders_info);
-
-        let mut commands = vec![];
-
-        if let Some(message) =
-            self.dkg_voter
-                .start_participating(self.node.name(), dkg_key, new_elders_info)
-        {
-            let token = command::next_timer_token();
-            self.dkg_voter.set_timer_token(token);
-
-            commands.push(Command::ScheduleTimeout {
-                duration: DKG_PROGRESS_INTERVAL,
-                token,
-            });
-            commands.extend(self.broadcast_dkg_message(dkg_key, message)?);
-        }
-
-        Ok(commands)
+        self.dkg_voter
+            .start_participating(&self.node, dkg_key, new_elders_info)
     }
 
     fn handle_dkg_result(
@@ -1069,91 +1068,20 @@ impl Approved {
         dkg_key: DkgKey,
         result: Result<bls::PublicKey, ()>,
         sender: XorName,
-    ) -> Result<Vec<Command>> {
-        let mut commands = vec![];
-
-        if sender == self.node.name() {
-            commands.push(self.send_dkg_result(dkg_key, result)?);
-        }
-
-        if !self.is_elder() {
-            return Ok(commands);
-        }
-
-        let (dkg_elders_info, result) =
-            if let Some(output) = self.dkg_voter.observe_result(&dkg_key, result, sender) {
-                output
-            } else {
-                return Ok(commands);
-            };
-
-        trace!(
-            "accumulated DKG result for {}: {:?}",
-            dkg_elders_info,
-            result
-        );
-
-        for new_elders_info in self
-            .section
-            .promote_and_demote_elders(&self.network_params, &self.node.name())
-        {
-            // Check whether the result still corresponds to the current elder candidates.
-            if new_elders_info == dkg_elders_info {
-                debug!("handle DKG result for {}: {:?}", new_elders_info, result);
-
-                if let Ok(public_key) = result {
-                    commands.extend(self.vote_for_section_update(public_key, new_elders_info)?)
-                } else {
-                    commands.extend(self.send_dkg_start(new_elders_info)?)
-                }
-            } else if new_elders_info.prefix == dkg_elders_info.prefix
-                || new_elders_info
-                    .prefix
-                    .is_extension_of(&dkg_elders_info.prefix)
-            {
-                trace!(
-                    "ignore DKG result for {}: {:?} - outdated",
-                    dkg_elders_info,
-                    result
-                );
-                commands.extend(self.send_dkg_start(new_elders_info)?);
-            }
-        }
-
-        Ok(commands)
+    ) -> Option<Command> {
+        self.dkg_voter.observe_result(&dkg_key, result, sender)
     }
 
-    pub fn handle_dkg_message(
+    fn handle_dkg_message(
         &mut self,
         dkg_key: DkgKey,
         message_bytes: Bytes,
         sender: XorName,
     ) -> Result<Vec<Command>> {
-        let mut commands = vec![];
-
         let message = bincode::deserialize(&message_bytes[..])?;
         trace!("handle DKG message {:?} from {}", message, sender);
 
-        let responses = self.dkg_voter.process_dkg_message(&dkg_key, message);
-
-        // Only a valid DkgMessage, which results in some responses, shall reset the ticker.
-        if !responses.is_empty() {
-            let token = command::next_timer_token();
-            commands.push(Command::ScheduleTimeout {
-                duration: DKG_PROGRESS_INTERVAL,
-                token,
-            });
-
-            self.dkg_voter.set_timer_token(token);
-        }
-
-        for response in responses {
-            commands.extend(self.broadcast_dkg_message(dkg_key, response)?);
-        }
-
-        commands.extend(self.check_dkg(dkg_key)?);
-
-        Ok(commands)
+        self.dkg_voter.process_message(&self.node, dkg_key, message)
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -1771,44 +1699,6 @@ impl Approved {
             recipients.len(),
             message.to_bytes(),
         ))
-    }
-
-    fn broadcast_dkg_message(
-        &mut self,
-        dkg_key: DkgKey,
-        dkg_message: DkgMessage,
-    ) -> Result<Vec<Command>> {
-        let dkg_message_bytes: Bytes = bincode::serialize(&dkg_message)?.into();
-        let variant = Variant::DKGMessage {
-            dkg_key,
-            message: dkg_message_bytes.clone(),
-        };
-        let message = Message::single_src(&self.node, DstLocation::Direct, variant, None, None)?;
-
-        let recipients: Vec<_> = self
-            .dkg_voter
-            .participants()
-            .filter(|peer| peer.name() != &self.node.name())
-            .map(Peer::addr)
-            .copied()
-            .collect();
-
-        trace!(
-            "broadcasting DKG message {:?} to {:?}",
-            dkg_message,
-            recipients
-        );
-
-        let mut commands = vec![];
-        commands.push(Command::send_message_to_targets(
-            &recipients,
-            recipients.len(),
-            message.to_bytes(),
-        ));
-
-        commands.extend(self.handle_dkg_message(dkg_key, dkg_message_bytes, self.node.name())?);
-
-        Ok(commands)
     }
 
     // Send message over the network.

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -240,15 +240,14 @@ impl Approved {
         elders_info: EldersInfo,
         result: Result<DkgOutcome, ()>,
     ) -> Result<Vec<Command>> {
-        let key = result
-            .as_ref()
-            .map(|outcome| outcome.public_key_set.public_key())
-            .map_err(|_| ());
-
-        if let Ok(outcome) = result {
+        let key = if let Ok(outcome) = result {
+            let key = outcome.public_key_set.public_key();
             self.section_keys_provider
                 .insert_dkg_outcome(&self.node.name(), &elders_info, outcome);
-        }
+            Ok(key)
+        } else {
+            Err(())
+        };
 
         let mut commands = vec![];
         commands.push(self.send_dkg_result(dkg_key, key)?);

--- a/src/routing/command.rs
+++ b/src/routing/command.rs
@@ -42,13 +42,15 @@ pub(crate) enum Command {
     HandleVote { vote: Vote, proof_share: ProofShare },
     /// Handle consensus on a vote.
     HandleConsensus { vote: Vote, proof: Proof },
-    /// Handle the result of a DKG session we are participating in
+    /// Handle the result of a DKG session where we are one of the participants (that is, one of
+    /// the proposed new elders).
     HandleDkgParticipationResult {
         dkg_key: DkgKey,
         elders_info: EldersInfo,
         result: Result<DkgOutcome, ()>,
     },
-    /// Handle the result of a DKG session we observing
+    /// Handle the result of a DKG session that we are an observer of (that is, one of the current
+    /// elders).
     HandleDkgObservationResult {
         elders_info: EldersInfo,
         result: Result<bls::PublicKey, ()>,

--- a/src/routing/command.rs
+++ b/src/routing/command.rs
@@ -7,11 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    consensus::{ProofShare, Vote},
+    consensus::{DkgKey, ProofShare, Vote},
     location::{DstLocation, SrcLocation},
     messages::Message,
     relocation::SignedRelocateDetails,
+    section::EldersInfo,
 };
+use bls_dkg::key_gen::outcome::Outcome as DkgOutcome;
 use bls_signature_aggregator::Proof;
 use bytes::Bytes;
 use std::{
@@ -40,6 +42,17 @@ pub(crate) enum Command {
     HandleVote { vote: Vote, proof_share: ProofShare },
     /// Handle consensus on a vote.
     HandleConsensus { vote: Vote, proof: Proof },
+    /// Handle the result of a DKG session we are participating in
+    HandleDkgParticipationResult {
+        dkg_key: DkgKey,
+        elders_info: EldersInfo,
+        result: Result<DkgOutcome, ()>,
+    },
+    /// Handle the result of a DKG session we observing
+    HandleDkgObservationResult {
+        elders_info: EldersInfo,
+        result: Result<bls::PublicKey, ()>,
+    },
     /// Send a message to `delivery_group_size` peers out of the given `recipients`.
     SendMessage {
         recipients: Vec<SocketAddr>,
@@ -105,6 +118,24 @@ impl Debug for Command {
                 .debug_struct("HandleConsensus")
                 .field("vote", vote)
                 .field("proof.public_key", &proof.public_key)
+                .finish(),
+            Self::HandleDkgParticipationResult {
+                dkg_key,
+                elders_info,
+                result,
+            } => f
+                .debug_struct("HandleDkgParticipationResult")
+                .field("dkg_key", dkg_key)
+                .field("elders_info", elders_info)
+                .field("result", result)
+                .finish(),
+            Self::HandleDkgObservationResult {
+                elders_info,
+                result,
+            } => f
+                .debug_struct("HandleDkgObservationResult")
+                .field("elders_info", elders_info)
+                .field("result", result)
                 .finish(),
             Self::SendMessage {
                 recipients,

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -6,11 +6,12 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+pub(crate) mod command;
+
 mod approved;
 mod bootstrap;
 mod comm;
-mod command;
-pub mod event_stream;
+mod event_stream;
 mod executor;
 mod stage;
 #[cfg(test)]

--- a/src/routing/stage.rs
+++ b/src/routing/stage.rs
@@ -69,6 +69,23 @@ impl Stage {
                     self.state.lock().await.handle_consensus(vote, proof)
                 }
                 Command::HandlePeerLost(addr) => self.state.lock().await.handle_peer_lost(&addr),
+                Command::HandleDkgParticipationResult {
+                    dkg_key,
+                    elders_info,
+                    result,
+                } => self.state.lock().await.handle_dkg_participation_result(
+                    dkg_key,
+                    elders_info,
+                    result,
+                ),
+                Command::HandleDkgObservationResult {
+                    elders_info,
+                    result,
+                } => self
+                    .state
+                    .lock()
+                    .await
+                    .handle_dkg_observation_result(elders_info, result),
                 Command::SendMessage {
                     recipients,
                     delivery_group_size,


### PR DESCRIPTION
This is a part of the effort to simplify the `Approved` struct by extracting parts of it into separate self-contained modules.