### PR TITLE
Startup tweaks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,5 @@ assert_matches = "1.3"
 env_logger = "~0.7.1"
 structopt = "~0.3.17"
 proptest = "0.10.1"
+rand = { version = "~0.7.3", features = ["small_rng"] }
 

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -109,7 +109,7 @@ impl DkgVoter {
     ) -> Vec<DkgCommand> {
         if let Some(session) = &self.participant {
             if session.dkg_key == dkg_key && session.elders_info.is_some() {
-                trace!("{} DKG for {} already in progress", our_name, elders_info);
+                trace!("DKG for {} already in progress", elders_info);
                 return vec![];
             }
         }
@@ -124,12 +124,7 @@ impl DkgVoter {
 
         match KeyGen::initialize(our_name, threshold, participants) {
             Ok((key_gen, message)) => {
-                trace!(
-                    "{} DKG for {:?} {} starting",
-                    our_name,
-                    dkg_key,
-                    elders_info
-                );
+                trace!("DKG for {} starting", elders_info);
 
                 let mut session = Participant {
                     dkg_key,
@@ -194,7 +189,7 @@ impl DkgVoter {
 
         let dkg_key = session.dkg_key;
 
-        trace!("{} DKG for {} progressing", our_name, elders_info);
+        trace!("DKG for {} progressing", elders_info);
 
         match session
             .key_gen
@@ -361,12 +356,7 @@ impl Participant {
             return vec![];
         }
 
-        trace!(
-            "{} process DKG message {:?} {:?}",
-            our_name,
-            dkg_key,
-            message
-        );
+        trace!("process DKG message {:?}", message);
         let responses = self
             .key_gen
             .handle_message(&mut rand::thread_rng(), message)
@@ -394,13 +384,7 @@ impl Participant {
             .copied()
             .collect();
 
-        trace!(
-            "{} broadcasting DKG message {:?} {:?} to {:?}",
-            our_name,
-            dkg_key,
-            message,
-            recipients
-        );
+        trace!("broadcasting DKG message {:?} to {:?}", message, recipients);
 
         let mut commands = vec![];
         commands.push(DkgCommand::SendMessage {

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -17,13 +17,14 @@ use crate::{
     section::EldersInfo,
     DstLocation,
 };
-use bls_dkg::key_gen::{message::Message as DkgMessage, KeyGen};
+use bls_dkg::key_gen::{message::Message as DkgMessage, outcome::Outcome as DkgOutcome, KeyGen};
 use hex_fmt::HexFmt;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     fmt::{self, Debug, Formatter},
+    net::SocketAddr,
     time::Duration,
 };
 use xor_name::XorName;
@@ -102,14 +103,14 @@ impl DkgVoter {
     // Starts a new DKG session as a participant.
     pub fn start_participating(
         &mut self,
-        node: &Node,
+        our_name: XorName,
         dkg_key: DkgKey,
         elders_info: EldersInfo,
-    ) -> Result<Vec<Command>> {
+    ) -> Vec<DkgCommand> {
         if let Some(session) = &self.participant {
             if session.dkg_key == dkg_key && session.elders_info.is_some() {
                 trace!("DKG for {} already in progress", elders_info);
-                return Ok(vec![]);
+                return vec![];
             }
         }
 
@@ -121,7 +122,7 @@ impl DkgVoter {
             .copied()
             .collect();
 
-        match KeyGen::initialize(node.name(), threshold, participants) {
+        match KeyGen::initialize(our_name, threshold, participants) {
             Ok((key_gen, message)) => {
                 trace!("DKG for {} starting", elders_info);
 
@@ -132,7 +133,7 @@ impl DkgVoter {
                     timer_token: 0,
                 };
 
-                let mut commands = session.broadcast(node, dkg_key, message)?;
+                let mut commands = session.broadcast(&our_name, dkg_key, message);
 
                 if let Some(command) = session.check() {
                     // Already completed.
@@ -142,12 +143,12 @@ impl DkgVoter {
                     self.participant = Some(session);
                 }
 
-                Ok(commands)
+                commands
             }
             Err(error) => {
                 // TODO: return error here
                 error!("DKG for {} failed to start: {}", elders_info, error);
-                Ok(vec![])
+                vec![]
             }
         }
     }
@@ -169,21 +170,21 @@ impl DkgVoter {
     }
 
     // Make key generator progress with timed phase.
-    pub fn handle_timeout(&mut self, node: &Node, timer_token: u64) -> Result<Vec<Command>> {
+    pub fn handle_timeout(&mut self, our_name: &XorName, timer_token: u64) -> Vec<DkgCommand> {
         let session = if let Some(session) = self.participant.as_mut() {
             session
         } else {
-            return Ok(vec![]);
+            return vec![];
         };
 
         if session.timer_token != timer_token {
-            return Ok(vec![]);
+            return vec![];
         }
 
         let elders_info = if let Some(elders_info) = session.elders_info.as_ref() {
             elders_info
         } else {
-            return Ok(vec![]);
+            return vec![];
         };
 
         let dkg_key = session.dkg_key;
@@ -198,12 +199,11 @@ impl DkgVoter {
                 let mut commands = vec![];
 
                 for message in messages {
-                    commands.extend(session.broadcast(node, dkg_key, message)?);
+                    commands.extend(session.broadcast(our_name, dkg_key, message));
                 }
                 commands.push(session.reset_timer());
                 commands.extend(self.check());
-
-                Ok(commands)
+                commands
             }
             Err(error) => {
                 trace!("DKG for {} failed: {}", elders_info, error);
@@ -212,11 +212,11 @@ impl DkgVoter {
 
                 self.participant = None;
 
-                Ok(vec![Command::HandleDkgParticipationResult {
+                vec![DkgCommand::HandleParticipationResult {
                     dkg_key,
                     elders_info,
                     result: Err(()),
-                }])
+                }]
             }
         }
     }
@@ -224,17 +224,17 @@ impl DkgVoter {
     // Handle a received DkgMessage.
     pub fn process_message(
         &mut self,
-        node: &Node,
+        our_name: &XorName,
         dkg_key: DkgKey,
         message: DkgMessage,
-    ) -> Result<Vec<Command>> {
+    ) -> Vec<DkgCommand> {
         let session = if let Some(session) = &mut self.participant {
             session
         } else {
-            return Ok(vec![]);
+            return vec![];
         };
 
-        let mut commands = session.process_message(node, dkg_key, message)?;
+        let mut commands = session.process_message(our_name, dkg_key, message);
 
         // Only a valid DkgMessage, which results in some responses, shall reset the ticker.
         if !commands.is_empty() {
@@ -242,8 +242,7 @@ impl DkgVoter {
         }
 
         commands.extend(self.check());
-
-        Ok(commands)
+        commands
     }
 
     // Observe and accumulate a DKG result (either success or failure).
@@ -252,7 +251,7 @@ impl DkgVoter {
         dkg_key: &DkgKey,
         result: Result<bls::PublicKey, ()>,
         sender: XorName,
-    ) -> Option<Command> {
+    ) -> Option<DkgCommand> {
         let session = self.observers.get_mut(dkg_key)?;
 
         if !session.elders_info.elders.contains_key(&sender) {
@@ -304,14 +303,14 @@ impl DkgVoter {
 
         let elders_info = if result.is_ok() {
             // On success, remove the sesssion because we don't need it anymore.
-            self.observers.remove(dkg_key).unwrap().elders_info
+            self.observers.remove(dkg_key)?.elders_info
         } else {
             // On failure, only clear the accumulator to allow new votes from restarted DKG
             session.accumulator.clear();
             session.elders_info.clone()
         };
 
-        Some(Command::HandleDkgObservationResult {
+        Some(DkgCommand::HandleObservationResult {
             elders_info,
             result,
         })
@@ -334,13 +333,13 @@ impl DkgVoter {
     }
 
     // Check whether a key generator is finalized to give a DKG outcome.
-    fn check(&mut self) -> Option<Command> {
+    fn check(&mut self) -> Option<DkgCommand> {
         let session = self.participant.as_mut()?;
         let command = session.check()?;
 
         // NOTE: Only reset `self.participant` on failed completion, because on success other nodes
         // might still need to receive DKG messages from us.
-        if matches!(command, Command::HandleDkgParticipationResult { result: Err(()), .. }) {
+        if matches!(command, DkgCommand::HandleParticipationResult { result: Err(()), .. }) {
             self.participant = None
         }
 
@@ -360,12 +359,12 @@ struct Participant {
 impl Participant {
     fn process_message(
         &mut self,
-        node: &Node,
+        our_name: &XorName,
         dkg_key: DkgKey,
         message: DkgMessage,
-    ) -> Result<Vec<Command>> {
+    ) -> Vec<DkgCommand> {
         if self.dkg_key != dkg_key {
-            return Ok(vec![]);
+            return vec![];
         }
 
         let responses = self
@@ -373,54 +372,41 @@ impl Participant {
             .handle_message(&mut rand::thread_rng(), message)
             .unwrap_or_default();
 
-        let mut commands = vec![];
-        for response in responses {
-            commands.extend(self.broadcast(node, dkg_key, response)?);
-        }
-
-        Ok(commands)
+        responses
+            .into_iter()
+            .flat_map(|response| self.broadcast(our_name, dkg_key, response))
+            .collect()
     }
 
     fn broadcast(
         &mut self,
-        node: &Node,
+        our_name: &XorName,
         dkg_key: DkgKey,
-        dkg_message: DkgMessage,
-    ) -> Result<Vec<Command>> {
+        message: DkgMessage,
+    ) -> Vec<DkgCommand> {
         let recipients: Vec<_> = self
             .elders_info
             .as_ref()
             .into_iter()
             .flat_map(EldersInfo::peers)
-            .filter(|peer| *peer.name() != node.name())
+            .filter(|peer| peer.name() != our_name)
             .map(Peer::addr)
             .copied()
             .collect();
 
-        trace!(
-            "broadcasting DKG message {:?} to {:?}",
-            dkg_message,
-            recipients
-        );
-
-        let variant = Variant::DKGMessage {
-            dkg_key,
-            message: bincode::serialize(&dkg_message)?.into(),
-        };
-        let message = Message::single_src(node, DstLocation::Direct, variant, None, None)?;
+        trace!("broadcasting DKG message {:?} to {:?}", message, recipients);
 
         let mut commands = vec![];
-        commands.push(Command::send_message_to_targets(
-            &recipients,
-            recipients.len(),
-            message.to_bytes(),
-        ));
-        commands.extend(self.process_message(node, dkg_key, dkg_message)?);
-
-        Ok(commands)
+        commands.push(DkgCommand::SendMessage {
+            recipients,
+            dkg_key,
+            message: message.clone(),
+        });
+        commands.extend(self.process_message(our_name, dkg_key, message));
+        commands
     }
 
-    fn check(&mut self) -> Option<Command> {
+    fn check(&mut self) -> Option<DkgCommand> {
         if !self.key_gen.is_finalized() {
             return None;
         }
@@ -435,7 +421,7 @@ impl Participant {
                 outcome.public_key_set.public_key()
             );
 
-            Some(Command::HandleDkgParticipationResult {
+            Some(DkgCommand::HandleParticipationResult {
                 dkg_key: self.dkg_key,
                 elders_info,
                 result: Ok(outcome),
@@ -447,7 +433,7 @@ impl Participant {
                 participants.iter().format(", ")
             );
 
-            Some(Command::HandleDkgParticipationResult {
+            Some(DkgCommand::HandleParticipationResult {
                 dkg_key: self.dkg_key,
                 elders_info,
                 result: Err(()),
@@ -455,9 +441,9 @@ impl Participant {
         }
     }
 
-    fn reset_timer(&mut self) -> Command {
+    fn reset_timer(&mut self) -> DkgCommand {
         self.timer_token = command::next_timer_token();
-        Command::ScheduleTimeout {
+        DkgCommand::ScheduleTimeout {
             duration: DKG_PROGRESS_INTERVAL,
             token: self.timer_token,
         }
@@ -472,13 +458,100 @@ struct Observer {
     accumulator: HashMap<Result<bls::PublicKey, ()>, HashSet<XorName>>,
 }
 
+pub(crate) enum DkgCommand {
+    SendMessage {
+        recipients: Vec<SocketAddr>,
+        dkg_key: DkgKey,
+        message: DkgMessage,
+    },
+    ScheduleTimeout {
+        duration: Duration,
+        token: u64,
+    },
+    HandleParticipationResult {
+        dkg_key: DkgKey,
+        elders_info: EldersInfo,
+        result: Result<DkgOutcome, ()>,
+    },
+    HandleObservationResult {
+        elders_info: EldersInfo,
+        result: Result<bls::PublicKey, ()>,
+    },
+}
+
+impl DkgCommand {
+    fn into_command(self, node: &Node) -> Result<Command> {
+        match self {
+            Self::SendMessage {
+                recipients,
+                dkg_key,
+                message,
+            } => {
+                let variant = Variant::DKGMessage {
+                    dkg_key,
+                    message: bincode::serialize(&message)?.into(),
+                };
+                let message = Message::single_src(node, DstLocation::Direct, variant, None, None)?;
+
+                Ok(Command::send_message_to_targets(
+                    &recipients,
+                    recipients.len(),
+                    message.to_bytes(),
+                ))
+            }
+            Self::ScheduleTimeout { duration, token } => {
+                Ok(Command::ScheduleTimeout { duration, token })
+            }
+            Self::HandleParticipationResult {
+                dkg_key,
+                elders_info,
+                result,
+            } => Ok(Command::HandleDkgParticipationResult {
+                dkg_key,
+                elders_info,
+                result,
+            }),
+            Self::HandleObservationResult {
+                elders_info,
+                result,
+            } => Ok(Command::HandleDkgObservationResult {
+                elders_info,
+                result,
+            }),
+        }
+    }
+}
+
+pub(crate) trait DkgCommands {
+    fn into_commands(self, node: &Node) -> Result<Vec<Command>>;
+}
+
+impl DkgCommands for Vec<DkgCommand> {
+    fn into_commands(self, node: &Node) -> Result<Vec<Command>> {
+        self.into_iter()
+            .map(|command| command.into_command(node))
+            .collect()
+    }
+}
+
+impl DkgCommands for Option<DkgCommand> {
+    fn into_commands(self, node: &Node) -> Result<Vec<Command>> {
+        self.into_iter()
+            .map(|command| command.into_command(node))
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
+        peer::test_utils::arbitrary_peer,
         section::test_utils::{gen_addr, gen_elders_info},
         ELDER_SIZE, MIN_AGE,
     };
+    use proptest::prelude::*;
+    use rand::{rngs::SmallRng, SeedableRng};
     use std::iter;
     use xor_name::Prefix;
 
@@ -581,5 +654,119 @@ mod tests {
         assert!(voter
             .observe_result(&dkg_key, Ok(pk1), nodes[majority - 1].name())
             .is_none());
+    }
+
+    proptest! {
+        // Run a DKG session where every participant handles every message sent to them.
+        // Expect the session to successfully complete without timed transitions.
+        // NOTE: `seed` is for seeding the rng that randomizes the message order.
+        #[test]
+        fn proptest_full_participation(peers in arbitrary_elder_peers(), seed: u64) {
+            proptest_full_participation_impl(peers, seed)
+        }
+    }
+
+    fn proptest_full_participation_impl(peers: Vec<Peer>, seed: u64) {
+        // Rng used to randomize the message order.
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mut messages = Vec::new();
+
+        let mut actors: HashMap<_, _> = peers
+            .iter()
+            .map(|peer| (*peer.addr(), Actor::new(*peer.name())))
+            .collect();
+
+        let elders_info = EldersInfo::new(peers, Prefix::default());
+        let dkg_key = DkgKey::new(&elders_info);
+
+        for actor in actors.values_mut() {
+            let commands =
+                actor
+                    .voter
+                    .start_participating(actor.name, dkg_key, elders_info.clone());
+
+            for command in commands {
+                messages.extend(actor.handle(command, &dkg_key))
+            }
+        }
+
+        loop {
+            match actors
+                .values()
+                .filter_map(|actor| actor.outcome.as_ref())
+                .unique()
+                .count()
+            {
+                0 => {}
+                1 => return,
+                _ => panic!("inconsistent DKG outcomes"),
+            }
+
+            // NOTE: this panics if `messages` is empty, but that's OK because it would mean
+            // failure anyway.
+            let index = rng.gen_range(0, messages.len());
+            let (addr, message) = messages.swap_remove(index);
+
+            let actor = actors.get_mut(&addr).expect("unknown message recipient");
+            let commands = actor.voter.process_message(&actor.name, dkg_key, message);
+
+            for command in commands {
+                messages.extend(actor.handle(command, &dkg_key))
+            }
+        }
+    }
+
+    struct Actor {
+        name: XorName,
+        voter: DkgVoter,
+        outcome: Option<bls::PublicKey>,
+    }
+
+    impl Actor {
+        fn new(name: XorName) -> Self {
+            Self {
+                name,
+                voter: DkgVoter::default(),
+                outcome: None,
+            }
+        }
+
+        fn handle(
+            &mut self,
+            command: DkgCommand,
+            expected_dkg_key: &DkgKey,
+        ) -> Vec<(SocketAddr, DkgMessage)> {
+            match command {
+                DkgCommand::SendMessage {
+                    recipients,
+                    dkg_key,
+                    message,
+                    ..
+                } => {
+                    assert_eq!(dkg_key, *expected_dkg_key);
+                    recipients
+                        .into_iter()
+                        .map(|addr| (addr, message.clone()))
+                        .collect()
+                }
+                DkgCommand::HandleParticipationResult {
+                    result: Ok(outcome),
+                    ..
+                } => {
+                    self.outcome = Some(outcome.public_key_set.public_key());
+                    vec![]
+                }
+                DkgCommand::HandleParticipationResult {
+                    result: Err(()), ..
+                } => panic!("DKG failed"),
+                DkgCommand::HandleObservationResult { .. } | DkgCommand::ScheduleTimeout { .. } => {
+                    vec![]
+                }
+            }
+        }
+    }
+
+    fn arbitrary_elder_peers() -> impl Strategy<Value = Vec<Peer>> {
+        proptest::collection::vec(arbitrary_peer(), 2..=ELDER_SIZE)
     }
 }

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -14,7 +14,7 @@ mod vote;
 
 pub use self::{dkg::DkgKey, proven::Proven};
 pub(crate) use self::{
-    dkg::DkgVoter,
+    dkg::{DkgCommands, DkgVoter},
     vote::{Vote, VoteAccumulator},
 };
 pub use bls_signature_aggregator::{AccumulationError, Proof, ProofShare, SignatureAggregator};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,15 +117,15 @@ pub(crate) const fn majority(num_possible_voters: usize) -> usize {
 }
 #[cfg(test)]
 mod tests {
+    use super::majority;
     use proptest::prelude::*;
 
-    use super::majority;
     proptest! {
         #[test]
-        fn pt_strict_majority(a in any::<usize>()) {
+        fn proptest_strict_majority(a in any::<usize>()) {
             let maj = majority(a);
             let maj_double = maj * 2;
-            assert!(maj_double == a || maj_double == a + 1 || maj_double == a + 2);
+            assert!(maj_double == a + 1 || maj_double == a + 2);
         }
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,7 @@
 use crate::{crypto, peer::Peer, MIN_AGE};
 use ed25519_dalek::Keypair;
 use std::{
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     net::SocketAddr,
     sync::Arc,
 };
@@ -51,5 +51,15 @@ impl Node {
 impl Display for Node {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "{}", self.name())
+    }
+}
+
+impl Debug for Node {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("Node")
+            .field("name", &self.name())
+            .field("addr", &self.addr)
+            .field("age", &self.age)
+            .finish()
     }
 }

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -64,3 +64,21 @@ impl Display for Peer {
         write!(f, "{} at {}", self.name, self.addr)
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use crate::MIN_AGE;
+
+    use super::*;
+    use proptest::prelude::*;
+    use xor_name::XOR_NAME_LEN;
+
+    pub(crate) fn arbitrary_xor_name() -> impl Strategy<Value = XorName> {
+        any::<[u8; XOR_NAME_LEN]>().prop_map(XorName)
+    }
+
+    pub(crate) fn arbitrary_peer() -> impl Strategy<Value = Peer> {
+        (arbitrary_xor_name(), any::<SocketAddr>(), MIN_AGE..)
+            .prop_map(|(name, addr, age)| Peer::new(name, addr, age))
+    }
+}

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -984,7 +984,7 @@ impl Approved {
         dkg_key: DkgKey,
         new_elders_info: EldersInfo,
     ) -> Result<Vec<Command>> {
-        trace!("{} Received DKGStart for {}", self.node, new_elders_info);
+        trace!("Received DKGStart for {}", new_elders_info);
         self.dkg_voter
             .start_participating(self.node.name(), dkg_key, new_elders_info)
             .into_commands(&self.node)
@@ -1577,14 +1577,9 @@ impl Approved {
     }
 
     fn send_dkg_start(&mut self, new_elders_info: EldersInfo) -> Result<Vec<Command>> {
-        let dkg_key = DkgKey::new(&new_elders_info);
+        trace!("Send DKGStart for {}", new_elders_info);
 
-        trace!(
-            "{} Send DKGStart for {:?} {}",
-            self.node,
-            dkg_key,
-            new_elders_info
-        );
+        let dkg_key = DkgKey::new(&new_elders_info);
 
         // Send to all participants.
         let recipients: Vec<_> = new_elders_info.elders.values().copied().collect();

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -88,7 +88,7 @@ impl Routing {
 
         let (event_tx, event_rx) = mpsc::unbounded_channel();
 
-        let (state, comm, incoming_msgs) = if config.first {
+        let (state, comm, incoming_msgs, backlog) = if config.first {
             info!("{} Starting a new network as the seed node.", node_name);
             let comm = Comm::new(config.transport_config)?;
             let incoming_msgs = comm.listen()?;
@@ -99,25 +99,36 @@ impl Routing {
             state.send_event(Event::Connected(Connected::First));
             state.send_event(Event::PromotedToElder);
 
-            (state, comm, incoming_msgs)
+            (state, comm, incoming_msgs, vec![])
         } else {
             info!("{} Bootstrapping a new node.", node_name);
             let (comm, bootstrap_addr) = Comm::from_bootstrapping(config.transport_config).await?;
             let mut incoming_msgs = comm.listen()?;
 
             let node = Node::new(keypair, comm.our_connection_info()?);
-            let (node, section) =
+            let (node, section, backlog) =
                 bootstrap::infant(node, &comm, &mut incoming_msgs, bootstrap_addr).await?;
             let state = Approved::new(node, section, None, event_tx);
 
             state.send_event(Event::Connected(Connected::First));
 
-            (state, comm, incoming_msgs)
+            (state, comm, incoming_msgs, backlog)
         };
 
         let stage = Arc::new(Stage::new(state, comm));
         let executor = Executor::new(stage.clone(), incoming_msgs).await;
         let event_stream = EventStream::new(event_rx);
+
+        // Process message backlog
+        for (message, sender) in backlog {
+            stage
+                .clone()
+                .handle_commands(Command::HandleMessage {
+                    message,
+                    sender: Some(sender),
+                })
+                .await?;
+        }
 
         let routing = Self {
             stage,

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -318,3 +318,9 @@ impl Routing {
             .ok_or(Error::InvalidState)
     }
 }
+
+impl Drop for Routing {
+    fn drop(&mut self) {
+        self.stage.cancel_timers()
+    }
+}

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -137,7 +137,7 @@ async fn test_section_bootstrapping() -> Result<()> {
 async fn test_startup_elders() -> Result<()> {
     // FIXME: using only 3 nodes for now because with 4 or more the test takes too long (but still
     // succeeds). Needs further investigation.
-    let network_size = 3;
+    let network_size = 4;
     let mut nodes = create_connected_nodes(network_size).await?;
 
     async fn expect_promote_event(stream: &mut EventStream) {

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -135,10 +135,7 @@ async fn test_section_bootstrapping() -> Result<()> {
 // Test that the first `ELDER_SIZE` nodes in the network are promoted to elders.
 #[tokio::test]
 async fn test_startup_elders() -> Result<()> {
-    // FIXME: using only 3 nodes for now because with 4 or more the test takes too long (but still
-    // succeeds). Needs further investigation.
-    let network_size = 4;
-    let mut nodes = create_connected_nodes(network_size).await?;
+    let mut nodes = create_connected_nodes(ELDER_SIZE).await?;
 
     async fn expect_promote_event(stream: &mut EventStream) {
         while let Some(event) = stream.next().await {


### PR DESCRIPTION
- Add proptest for DKG
- Remove DKG bounce. The issue it was supposed to fix was not reproducible in tests and the implementation was problematic. For example, it only handled the initial DKG after a node joins, but not the subsequent DKGs. Fixing that was tricky, because it's difficult to tell whether an incoming DKG message for an unknown session should be bounced because the session is only about to be created, or ignored because the session was already discarded. There might be ways to fix this, but it doesn't seem worth the complexity at the moment. We might want to revisit this in a different PR if necessary.
- Add bootstrap message backlog - cache unknown messages during the bootstrap phase, then process them after being bootstrapped.
- Prevent scheduled timeouts from keeping `Stage` alive even after `Routing` is dropped. Results in faster offline detection. 