### PR TITLE
feat: allow rejoin with same name

### DIFF
--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -1086,7 +1086,7 @@ impl Approved {
         self.send_relocate(&peer, details)
     }
 
-    fn relocate_rejoin_peer(&self, peer: Peer, age: u8) -> Result<Vec<Command>> {
+    fn relocate_rejoining_peer(&self, peer: Peer, age: u8) -> Result<Vec<Command>> {
         let details =
             RelocateDetails::with_age(&self.section, &self.network, &peer, *peer.name(), age);
 
@@ -1137,7 +1137,7 @@ impl Approved {
                 // to send this `NodeApproval`.
                 commands.push(self.send_node_approval(&peer, their_knowledge)?);
                 commands.extend(
-                    self.relocate_rejoin_peer(peer, cmp::max(MIN_AGE, info.peer.age() / 2))?,
+                    self.relocate_rejoining_peer(peer, cmp::max(MIN_AGE, info.peer.age() / 2))?,
                 );
                 return Ok(commands);
             }

--- a/src/routing/tests/mod.rs
+++ b/src/routing/tests/mod.rs
@@ -449,7 +449,7 @@ async fn handle_consensus_on_offline_of_elder() -> Result<()> {
         .members()
         .get(remove_peer.name())
         .expect("member not found")
-        .leave();
+        .leave()?;
 
     // Create our node
     let (event_tx, mut event_rx) = mpsc::unbounded_channel();

--- a/src/section/member_info.rs
+++ b/src/section/member_info.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use crate::peer::Peer;
+use crate::{error::Error, peer::Peer};
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
@@ -35,11 +35,15 @@ impl MemberInfo {
         self.peer.age() > MIN_AGE
     }
 
-    pub fn leave(self) -> Self {
-        Self {
+    pub fn leave(self) -> Result<Self, Error> {
+        // Do not vote Offline when already relocated, to avoid rejoining with the same name.
+        if let PeerState::Relocated(_) = self.state {
+            return Err(Error::InvalidState);
+        }
+        Ok(Self {
             state: PeerState::Left,
             ..self
-        }
+        })
     }
 
     // Convert this info into one with the state changed to `Relocated`.


### PR DESCRIPTION
As discussed, rejoin node with same name will be immediately relocated with half of original age.

Close https://github.com/maidsafe/sn_routing/issues/2214