### PR TITLE
feat: joins_allowed to toggle accept new node or not

### DIFF
--- a/src/consensus/vote.rs
+++ b/src/consensus/vote.rs
@@ -58,6 +58,9 @@ pub(crate) enum Vote {
         message: Box<PlainMessage>,
         proof_chain: SectionProofChain,
     },
+
+    // Voted to concensus whether new node shall be allowed to join
+    JoinsAllowed(bool),
 }
 
 impl Vote {
@@ -95,6 +98,7 @@ impl<'a> Serialize for SignableView<'a> {
             Vote::TheirKey { prefix, key } => (prefix, key).serialize(serializer),
             Vote::TheirKnowledge { prefix, key_index } => (prefix, key_index).serialize(serializer),
             Vote::SendMessage { message, .. } => message.as_signable().serialize(serializer),
+            Vote::JoinsAllowed(joins_allowed) => joins_allowed.serialize(serializer),
         }
     }
 }

--- a/src/routing/command.rs
+++ b/src/routing/command.rs
@@ -81,6 +81,8 @@ pub(crate) enum Command {
         /// Message receiver to pass to the bootstrap task.
         message_rx: mpsc::Receiver<(Message, SocketAddr)>,
     },
+    /// Attempt to set JoinsAllowed flag.
+    SetJoinsAllowed(bool),
 }
 
 impl Command {
@@ -178,6 +180,10 @@ impl Debug for Command {
                 .debug_struct("Relocate")
                 .field("bootstrap_addrs", bootstrap_addrs)
                 .field("details", details)
+                .finish(),
+            Self::SetJoinsAllowed(joins_allowed) => f
+                .debug_tuple("SetJoinsAllowed")
+                .field(joins_allowed)
                 .finish(),
         }
     }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -137,6 +137,12 @@ impl Routing {
         Ok((routing, event_stream))
     }
 
+    /// Sets the JoinsAllowed flag.
+    pub async fn set_joins_allowed(&self, joins_allowed: bool) -> Result<()> {
+        let command = Command::SetJoinsAllowed(joins_allowed);
+        self.stage.clone().handle_commands(command).await
+    }
+
     /// Returns the current age of this node.
     pub async fn age(&self) -> u8 {
         self.stage.state.lock().await.node().age

--- a/src/routing/stage.rs
+++ b/src/routing/stage.rs
@@ -124,6 +124,9 @@ impl Stage {
                     self.handle_relocate(bootstrap_addrs, details, message_rx)
                         .await
                 }
+                Command::SetJoinsAllowed(joins_allowed) => {
+                    self.state.lock().await.set_joins_allowed(joins_allowed)
+                }
             }
         }
         .await;


### PR DESCRIPTION
This contains the work to allow node to tell routing whether new node shall be accepted.
This is also being a solution to prevent sybil attack. 