### PR TITLE
Refactor section update

### DIFF
--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -58,6 +58,9 @@ impl DkgKey {
         Self(output)
     }
 
+    // Create a new `DkgKey` to be used to retry a previously failed DKG session. This key is
+    // deterministically derived from `self`, so different DKG participants that fail at different
+    // times end up using the same retried key.
     pub fn retry(&self) -> Self {
         use tiny_keccak::{Hasher, Sha3};
 
@@ -166,6 +169,8 @@ impl DkgVoter {
         }
     }
 
+    // Try to initialize a DKG session. If it succeeds, returns a list of `DkgCommand`s to apply.
+    // On failure gives back `elders_info` so it can be used again to retry, avoiding a clone.
     fn try_initialize(
         &mut self,
         our_name: XorName,

--- a/src/consensus/dkg.rs
+++ b/src/consensus/dkg.rs
@@ -379,6 +379,14 @@ impl Session {
     }
 
     fn process_failure(&mut self, proof: DkgFailureProof) -> Option<DkgCommand> {
+        if !self
+            .elders_info
+            .elders
+            .contains_key(&crypto::name(&proof.public_key))
+        {
+            return None;
+        }
+
         if !proof.verify(&self.dkg_key) {
             return None;
         }
@@ -436,6 +444,8 @@ impl DkgFailureProof {
 pub(crate) struct DkgFailureProofSet(Vec<DkgFailureProof>);
 
 impl DkgFailureProofSet {
+    // Insert a proof into this set. The proof is assumed valid. Returns `true` if the proof was
+    // not already present in the set and `false` otherwise.
     fn insert(&mut self, proof: DkgFailureProof) -> bool {
         if self
             .0
@@ -449,6 +459,8 @@ impl DkgFailureProofSet {
         }
     }
 
+    // Check whether we have proofs from a majority of the participants. The contained proofs are
+    // assumed valid.
     fn has_agreement(&self, elders_info: &EldersInfo) -> bool {
         self.0.len() >= majority(elders_info.elders.len())
     }

--- a/src/consensus/mod.rs
+++ b/src/consensus/mod.rs
@@ -14,7 +14,7 @@ mod vote;
 
 pub use self::{dkg::DkgKey, proven::Proven};
 pub(crate) use self::{
-    dkg::{DkgCommands, DkgVoter},
+    dkg::{DkgCommands, DkgFailureProof, DkgFailureProofSet, DkgVoter},
     vote::{Vote, VoteAccumulator},
 };
 pub use bls_signature_aggregator::{AccumulationError, Proof, ProofShare, SignatureAggregator};

--- a/src/consensus/vote.rs
+++ b/src/consensus/vote.rs
@@ -34,8 +34,15 @@ pub(crate) enum Vote {
     SectionInfo(EldersInfo),
 
     // Voted to update the elders in our section.
-    // NOTE: the `EldersInfo` is already signed with the new key. All that's left to do is to sign
-    // the new key using our current key, which is what this vote is for.
+    // NOTE: the `EldersInfo` is already signed with the new key. This vote is only to signs the
+    // new key with the current key. That way, when it accumulates, we obtain all the following
+    // pieces of information at the same time:
+    //   1. the new elders info
+    //   2. the new key
+    //   3. the signature of the new elders info using the new key
+    //   4. the signature of the new key using the current key
+    // Which we can use to update the section elders info and the section chain at the same time as
+    // a single atomic operation without needing to cache anything.
     OurElders(Proven<EldersInfo>),
 
     // Voted to update their section key.

--- a/src/consensus/vote.rs
+++ b/src/consensus/vote.rs
@@ -33,6 +33,9 @@ pub(crate) enum Vote {
     // Voted to update the elders info of a section.
     SectionInfo(EldersInfo),
 
+    // TODO: remove this variant and use `SectionInfo` instead.
+    DKGResult(EldersInfo),
+
     // Voted to update our section key.
     OurKey {
         // In case of split, this prefix is used to differentiate the subsections. It's not part of
@@ -93,7 +96,7 @@ impl<'a> Serialize for SignableView<'a> {
         match self.0 {
             Vote::Online { member_info, .. } => member_info.serialize(serializer),
             Vote::Offline(member_info) => member_info.serialize(serializer),
-            Vote::SectionInfo(info) => info.serialize(serializer),
+            Vote::SectionInfo(info) | Vote::DKGResult(info) => info.serialize(serializer),
             Vote::OurKey { key, .. } => key.serialize(serializer),
             Vote::TheirKey { prefix, key } => (prefix, key).serialize(serializer),
             Vote::TheirKnowledge { prefix, key_index } => (prefix, key_index).serialize(serializer),

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -59,3 +59,22 @@ pub fn gen_keypair_within_range(range: &RangeInclusive<XorName>) -> Keypair {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use super::*;
+    use ed25519_dalek::SECRET_KEY_LENGTH;
+    use proptest::prelude::*;
+
+    pub(crate) fn arbitrary_keypair() -> impl Strategy<Value = Keypair> {
+        any::<[u8; SECRET_KEY_LENGTH]>().prop_map(|bytes| {
+            // OK to unwrap because `from_bytes` returns error only if the input slice has incorrect
+            // length. But here we only generate arrays of size `SECRET_KEY_LENGTH` which is the
+            // correct one.
+            let secret = SecretKey::from_bytes(&bytes[..]).unwrap();
+            let public = PublicKey::from(&secret);
+
+            Keypair { public, secret }
+        })
+    }
+}

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -314,6 +314,7 @@ pub enum VerifyStatus {
 }
 
 /// Status of an incomming message.
+#[derive(Eq, PartialEq)]
 pub enum MessageStatus {
     /// Message is useful and should be handled.
     Useful,

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -8,7 +8,7 @@
 
 use super::{Message, MessageHash, VerifyStatus};
 use crate::{
-    consensus::{DkgKey, ProofShare, Proven, Vote},
+    consensus::{DkgFailureProof, DkgFailureProofSet, DkgKey, ProofShare, Proven, Vote},
     crypto::Signature,
     error::{Error, Result},
     network::Network,
@@ -90,6 +90,17 @@ pub(crate) enum Variant {
         dkg_key: DkgKey,
         /// The DKG message.
         message: DkgMessage,
+    },
+    /// Broadcasted to the other DKG participants when a DKG failure is observed.
+    DKGFailureObservation {
+        dkg_key: DkgKey,
+        proof: DkgFailureProof,
+    },
+    /// Sent to the current elders by the DKG participants when at least majority of them observe
+    /// a DKG failure.
+    DKGFailureAgreement {
+        elders_info: EldersInfo,
+        proofs: DkgFailureProofSet,
     },
     /// Message containing a single `Vote` to be accumulated in the vote accumulator.
     Vote {
@@ -187,6 +198,19 @@ impl Debug for Variant {
                 .debug_struct("DKGMessage")
                 .field("dkg_key", &dkg_key)
                 .field("message", message)
+                .finish(),
+            Self::DKGFailureObservation { dkg_key, proof } => f
+                .debug_struct("DKGFailureObservation")
+                .field("dkg_key", dkg_key)
+                .field("proof", proof)
+                .finish(),
+            Self::DKGFailureAgreement {
+                elders_info,
+                proofs,
+            } => f
+                .debug_struct("DKGFailureAgreement")
+                .field("elders_info", elders_info)
+                .field("proofs", proofs)
                 .finish(),
             Self::Vote {
                 content,

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -91,13 +91,6 @@ pub(crate) enum Variant {
         /// The DKG message.
         message: DkgMessage,
     },
-    /// Message to notify current elders about the DKG result.
-    DKGResult {
-        /// The identifier of the DKG session the result is for.
-        dkg_key: DkgKey,
-        /// The key outputted by the DKG.
-        public_key: bls::PublicKey,
-    },
     /// Message containing a single `Vote` to be accumulated in the vote accumulator.
     Vote {
         content: Vote,
@@ -194,14 +187,6 @@ impl Debug for Variant {
                 .debug_struct("DKGMessage")
                 .field("dkg_key", &dkg_key)
                 .field("message", message)
-                .finish(),
-            Self::DKGResult {
-                dkg_key,
-                public_key,
-            } => f
-                .debug_struct("DKGResult")
-                .field("dkg_key", dkg_key)
-                .field("public_key", public_key)
                 .finish(),
             Self::Vote {
                 content,

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -95,8 +95,8 @@ pub(crate) enum Variant {
     DKGResult {
         /// The identifier of the DKG session the result is for.
         dkg_key: DkgKey,
-        /// The result of the DKG.
-        result: Result<bls::PublicKey, ()>,
+        /// The key outputted by the DKG.
+        public_key: bls::PublicKey,
     },
     /// Message containing a single `Vote` to be accumulated in the vote accumulator.
     Vote {
@@ -195,10 +195,13 @@ impl Debug for Variant {
                 .field("dkg_key", &dkg_key)
                 .field("message", message)
                 .finish(),
-            Self::DKGResult { dkg_key, result } => f
+            Self::DKGResult {
+                dkg_key,
+                public_key,
+            } => f
                 .debug_struct("DKGResult")
                 .field("dkg_key", dkg_key)
-                .field("result", result)
+                .field("public_key", public_key)
                 .finish(),
             Self::Vote {
                 content,

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -6,7 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::{Command, UpdateBarrier};
+use super::{Command, SplitBarrier};
 use crate::{
     consensus::{
         AccumulationError, DkgCommands, DkgKey, DkgVoter, Proof, ProofShare, Proven, Vote,
@@ -54,7 +54,7 @@ pub(crate) struct Approved {
     network: Network,
     section_keys_provider: SectionKeysProvider,
     vote_accumulator: VoteAccumulator,
-    update_barrier: UpdateBarrier,
+    split_barrier: SplitBarrier,
     // Voter for DKG
     dkg_voter: DkgVoter,
     relocate_state: Option<RelocateState>,
@@ -86,7 +86,7 @@ impl Approved {
             network: Network::new(),
             section_keys_provider,
             vote_accumulator: Default::default(),
-            update_barrier: Default::default(),
+            split_barrier: Default::default(),
             dkg_voter: Default::default(),
             relocate_state: None,
             msg_filter: MessageFilter::new(),
@@ -1280,7 +1280,7 @@ impl Approved {
         elders_info: Proven<EldersInfo>,
         key_proof: Proof,
     ) -> Result<Vec<Command>> {
-        self.update_barrier.handle_our_section(
+        self.split_barrier.handle_our_section(
             &self.node.name(),
             &self.section,
             &self.network,
@@ -1299,7 +1299,7 @@ impl Approved {
         let key = Proven::new((prefix, key), proof);
 
         if key.value.0.is_extension_of(self.section.prefix()) {
-            self.update_barrier.handle_their_key(
+            self.split_barrier.handle_their_key(
                 &self.node.name(),
                 &self.section,
                 &self.network,
@@ -1337,7 +1337,7 @@ impl Approved {
     fn try_update_state(&mut self) -> Result<Vec<Command>> {
         let mut commands = vec![];
 
-        let (our, sibling) = self.update_barrier.take(self.section.prefix());
+        let (our, sibling) = self.split_barrier.take(self.section.prefix());
 
         if let Some(our) = our {
             trace!("update our section: {:?}", our.section.elders_info());

--- a/src/routing/command.rs
+++ b/src/routing/command.rs
@@ -49,7 +49,7 @@ pub(crate) enum Command {
         elders_info: EldersInfo,
         outcome: SectionKeyShare,
     },
-    /// Handle DKG failure
+    /// Handle a DKG failure that was observed by a majority of the DKG participants.
     HandleDkgFailure {
         elders_info: EldersInfo,
         proofs: DkgFailureProofSet,

--- a/src/routing/command.rs
+++ b/src/routing/command.rs
@@ -7,7 +7,7 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use crate::{
-    consensus::{ProofShare, Vote},
+    consensus::{DkgFailureProofSet, ProofShare, Vote},
     location::{DstLocation, SrcLocation},
     messages::Message,
     relocation::SignedRelocateDetails,
@@ -48,6 +48,11 @@ pub(crate) enum Command {
     HandleDkgOutcome {
         elders_info: EldersInfo,
         outcome: SectionKeyShare,
+    },
+    /// Handle DKG failure
+    HandleDkgFailure {
+        elders_info: EldersInfo,
+        proofs: DkgFailureProofSet,
     },
     /// Send a message to `delivery_group_size` peers out of the given `recipients`.
     SendMessage {
@@ -127,6 +132,14 @@ impl Debug for Command {
                 .debug_struct("HandleDkgOutcome")
                 .field("elders_info", elders_info)
                 .field("outcome", &outcome.public_key_set.public_key())
+                .finish(),
+            Self::HandleDkgFailure {
+                elders_info,
+                proofs,
+            } => f
+                .debug_struct("HandleDkgFailure")
+                .field("elders_info", elders_info)
+                .field("proofs", proofs)
                 .finish(),
             Self::SendMessage {
                 recipients,

--- a/src/routing/command.rs
+++ b/src/routing/command.rs
@@ -49,13 +49,13 @@ pub(crate) enum Command {
     HandleDkgParticipationResult {
         dkg_key: DkgKey,
         elders_info: EldersInfo,
-        result: Result<DkgOutcome, ()>,
+        outcome: DkgOutcome,
     },
     /// Handle the result of a DKG session that we are an observer of (that is, one of the current
     /// elders).
     HandleDkgObservationResult {
         elders_info: EldersInfo,
-        result: Result<bls::PublicKey, ()>,
+        public_key: bls::PublicKey,
     },
     /// Send a message to `delivery_group_size` peers out of the given `recipients`.
     SendMessage {
@@ -131,25 +131,20 @@ impl Debug for Command {
             Self::HandleDkgParticipationResult {
                 dkg_key,
                 elders_info,
-                result,
+                outcome,
             } => f
                 .debug_struct("HandleDkgParticipationResult")
                 .field("dkg_key", dkg_key)
                 .field("elders_info", elders_info)
-                .field(
-                    "result",
-                    &result
-                        .as_ref()
-                        .map(|outcome| outcome.public_key_set.public_key()),
-                )
+                .field("outcome", &outcome.public_key_set.public_key())
                 .finish(),
             Self::HandleDkgObservationResult {
                 elders_info,
-                result,
+                public_key,
             } => f
                 .debug_struct("HandleDkgObservationResult")
                 .field("elders_info", elders_info)
-                .field("result", result)
+                .field("public_key", public_key)
                 .finish(),
             Self::SendMessage {
                 recipients,

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -12,18 +12,18 @@ mod approved;
 mod bootstrap;
 mod comm;
 mod event_stream;
+mod split_barrier;
 mod stage;
 #[cfg(test)]
 mod tests;
-mod update_barrier;
 
 pub use self::event_stream::EventStream;
 use self::{
     approved::Approved,
     comm::{Comm, ConnectionEvent},
     command::Command,
+    split_barrier::SplitBarrier,
     stage::Stage,
-    update_barrier::UpdateBarrier,
 };
 use crate::{
     crypto,

--- a/src/routing/stage.rs
+++ b/src/routing/stage.rs
@@ -116,23 +116,14 @@ impl Stage {
                 .into_iter()
                 .collect()),
             Command::HandlePeerLost(addr) => self.state.lock().await.handle_peer_lost(&addr),
-            Command::HandleDkgParticipationResult {
-                dkg_key,
+            Command::HandleDkgOutcome {
                 elders_info,
                 outcome,
-            } => self.state.lock().await.handle_dkg_participation_result(
-                dkg_key,
-                elders_info,
-                outcome,
-            ),
-            Command::HandleDkgObservationResult {
-                elders_info,
-                public_key,
             } => self
                 .state
                 .lock()
                 .await
-                .handle_dkg_observation_result(elders_info, public_key),
+                .handle_dkg_outcome(elders_info, outcome),
             Command::SendMessage {
                 recipients,
                 delivery_group_size,

--- a/src/routing/stage.rs
+++ b/src/routing/stage.rs
@@ -119,20 +119,20 @@ impl Stage {
             Command::HandleDkgParticipationResult {
                 dkg_key,
                 elders_info,
-                result,
+                outcome,
             } => self.state.lock().await.handle_dkg_participation_result(
                 dkg_key,
                 elders_info,
-                result,
+                outcome,
             ),
             Command::HandleDkgObservationResult {
                 elders_info,
-                result,
+                public_key,
             } => self
                 .state
                 .lock()
                 .await
-                .handle_dkg_observation_result(elders_info, result),
+                .handle_dkg_observation_result(elders_info, public_key),
             Command::SendMessage {
                 recipients,
                 delivery_group_size,

--- a/src/routing/stage.rs
+++ b/src/routing/stage.rs
@@ -124,6 +124,15 @@ impl Stage {
                 .lock()
                 .await
                 .handle_dkg_outcome(elders_info, outcome),
+            Command::HandleDkgFailure {
+                elders_info,
+                proofs,
+            } => self
+                .state
+                .lock()
+                .await
+                .handle_dkg_failure(elders_info, proofs)
+                .map(|command| vec![command]),
             Command::SendMessage {
                 recipients,
                 delivery_group_size,

--- a/src/section/section_keys.rs
+++ b/src/section/section_keys.rs
@@ -6,10 +6,7 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use super::EldersInfo;
 use crate::error::{Error, Result};
-use bls_dkg::key_gen::outcome::Outcome;
-use xor_name::XorName;
 
 /// All the key material needed to sign or combine signature for our section key.
 #[derive(Debug)]
@@ -43,20 +40,8 @@ impl SectionKeysProvider {
         self.current.as_ref().ok_or(Error::MissingSecretKeyShare)
     }
 
-    pub fn insert_dkg_outcome(
-        &mut self,
-        our_name: &XorName,
-        elders_info: &EldersInfo,
-        dkg_outcome: Outcome,
-    ) {
-        if let Some(index) = elders_info.position(our_name) {
-            let share = SectionKeyShare {
-                public_key_set: dkg_outcome.public_key_set,
-                index,
-                secret_key_share: dkg_outcome.secret_key_share,
-            };
-            self.pending = Some(share);
-        }
+    pub fn insert_dkg_outcome(&mut self, share: SectionKeyShare) {
+        self.pending = Some(share);
     }
 
     pub fn finalise_dkg(&mut self, public_key: &bls::PublicKey) {


### PR DESCRIPTION
This PR refactors the DKG and its outcome handling in order to simplify the codebase:

- ~~DKG failures are no longer reported to the current elders. If a DKG participant detects a failure, it automatically restarts the DKG~~
- DKG failures are still reported, but differently - they are now accumulated by the DKG participants themselves and only when they accumulate a majority are they sent to the current elders. The elders validate it and restart the DKG if necessary. This makes things simpler because we don't need to track potentially multiple DKG sessions or deal with the invalidation of the accumulators. It also offloads the work to the nodes that benefit from it, which seems neater.
- The separate DKG result accumulator is gone. We now use the regular vote accumulator.
- So there is no more special state for "DKG observer".
- Section elders and section key are now naturally updated at the same time, without requiring a separate synchronization
- So the `UpdateBarrier` is now needed only during splits and thus got simplified and renamed to `SplitBarrier`
