### PR TITLE
Do not expose BLS secret key share

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,8 +37,8 @@ pub enum Error {
     UntrustedMessage,
     #[error(display = "A signature share is invalid.")]
     InvalidSignatureShare,
-    #[error(display = "An Elder DKG result is invalid.")]
-    InvalidElderDkgResult,
+    #[error(display = "The secret key share is missing.")]
+    MissingSecretKeyShare,
     #[error(display = "Failed to send a message.")]
     FailedSend,
     #[error(display = "Invalid vote.")]

--- a/src/section/section_keys.rs
+++ b/src/section/section_keys.rs
@@ -12,7 +12,7 @@ use bls_dkg::key_gen::outcome::Outcome;
 use xor_name::XorName;
 
 /// All the key material needed to sign or combine signature for our section key.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct SectionKeyShare {
     /// Public key set to verify threshold signatures and combine shares.
     pub public_key_set: bls::PublicKeySet,
@@ -40,7 +40,7 @@ impl SectionKeysProvider {
     }
 
     pub fn key_share(&self) -> Result<&SectionKeyShare> {
-        self.current.as_ref().ok_or(Error::InvalidElderDkgResult)
+        self.current.as_ref().ok_or(Error::MissingSecretKeyShare)
     }
 
     pub fn insert_dkg_outcome(


### PR DESCRIPTION
BREAKING CHANGE:
    - remove `Routing::secret_key_share` (use `Routing::sign_with_secret_key_share` instead).
    - Rename `Error::InvalidElderDkgResult` to `Error::MissingSecretKeyShare`
    - `Routing::public_key_set` and `Routing::our_index` now return `MissingSecretKeyShare` instead of `InvalidState` on error.