### PR TITLE
feat: carry out resource proofing during bootstrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ qp2p = "~0.9.1"
 rand = "~0.7.3"
 rand_chacha = "~0.2.2"
 xor_name = "1.1.0"
+resource_proof = "0.8.0"
 
   [dependencies.bls]
   package = "threshold_crypto"

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -14,7 +14,7 @@ mod variant;
 pub use self::{hash::MessageHash, src_authority::SrcAuthority};
 pub(crate) use self::{
     plain_message::PlainMessage,
-    variant::{BootstrapResponse, JoinRequest, Proof, Variant},
+    variant::{BootstrapResponse, JoinRequest, ResourceProofResponse, Variant},
 };
 use crate::{
     crypto::{self, name, Verifier},

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -14,7 +14,7 @@ mod variant;
 pub use self::{hash::MessageHash, src_authority::SrcAuthority};
 pub(crate) use self::{
     plain_message::PlainMessage,
-    variant::{BootstrapResponse, JoinRequest, Variant},
+    variant::{BootstrapResponse, JoinRequest, Proof, Variant},
 };
 use crate::{
     crypto::{self, name, Verifier},

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -19,6 +19,7 @@ use bytes::Bytes;
 use hex_fmt::HexFmt;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::VecDeque,
     fmt::{self, Debug, Formatter},
     net::SocketAddr,
 };
@@ -215,6 +216,12 @@ pub enum BootstrapResponse {
     /// The new peer should retry bootstrapping with another section. The set of connection infos
     /// of the members of that section is provided.
     Rebootstrap(Vec<SocketAddr>),
+    /// Expecting the new peer to carry out a resouce proofing.
+    ResourceProof {
+        data_size: usize,
+        difficulty: u8,
+        nonce: [u8; 32],
+    },
 }
 
 /// Request to join a section
@@ -224,6 +231,8 @@ pub(crate) struct JoinRequest {
     pub section_key: bls::PublicKey,
     /// If the peer is being relocated, contains `RelocatePayload`. Otherwise contains `None`.
     pub relocate_payload: Option<RelocatePayload>,
+    /// Proof of the resouce proofing
+    pub resource_proof: Option<(u64, VecDeque<u8>)>,
 }
 
 impl Debug for JoinRequest {
@@ -237,6 +246,10 @@ impl Debug for JoinRequest {
                     .relocate_payload
                     .as_ref()
                     .map(|payload| payload.relocate_details()),
+            )
+            .field(
+                "resouce_proof",
+                &self.resource_proof.as_ref().map(|(solution, _)| solution),
             )
             .finish()
     }

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -104,11 +104,11 @@ pub(crate) enum Variant {
         proof_share: ProofShare,
     },
     /// Challenge sent from existing elder nodes to the joining peer for resource proofing.
-    Challenge {
+    ResourceChallenge {
         data_size: usize,
         difficulty: u8,
         nonce: [u8; 32],
-        signature: Signature,
+        nonce_signature: Signature,
     },
 }
 
@@ -208,12 +208,12 @@ impl Debug for Variant {
                 .field("content", content)
                 .field("proof_share", proof_share)
                 .finish(),
-            Self::Challenge {
+            Self::ResourceChallenge {
                 data_size,
                 difficulty,
                 ..
             } => f
-                .debug_struct("Challenge")
+                .debug_struct("ResourceChallenge")
                 .field("data_size", data_size)
                 .field("difficulty", difficulty)
                 .finish(),
@@ -237,22 +237,22 @@ pub enum BootstrapResponse {
 
 /// Joining peer's proof of resolvement of given resource proofing challenge.
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub(crate) struct Proof {
+pub(crate) struct ResourceProofResponse {
     pub(crate) solution: u64,
     pub(crate) data: VecDeque<u8>,
     pub(crate) nonce: [u8; 32],
-    pub(crate) signature: Signature,
+    pub(crate) nonce_signature: Signature,
 }
 
 /// Request to join a section
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct JoinRequest {
-    /// The public key of the section to join
+    /// The public key of the section to join.
     pub section_key: bls::PublicKey,
     /// If the peer is being relocated, contains `RelocatePayload`. Otherwise contains `None`.
     pub relocate_payload: Option<RelocatePayload>,
-    /// Proof of the resouce proofing
-    pub proof: Option<Proof>,
+    /// Proof of the resouce proofing.
+    pub resource_proof_response: Option<ResourceProofResponse>,
 }
 
 impl Debug for JoinRequest {
@@ -267,7 +267,13 @@ impl Debug for JoinRequest {
                     .as_ref()
                     .map(|payload| payload.relocate_details()),
             )
-            .field("proof", &self.proof.as_ref().map(|proof| proof.solution))
+            .field(
+                "resource_proof_response",
+                &self
+                    .resource_proof_response
+                    .as_ref()
+                    .map(|proof| proof.solution),
+            )
             .finish()
     }
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -109,7 +109,7 @@ impl Routing {
                 Comm::bootstrap(config.transport_config, connection_event_tx).await?;
             let node = Node::new(keypair, comm.our_connection_info().await?);
             let (node, section, backlog) =
-                bootstrap::infant(node, &comm, &mut connection_event_rx, bootstrap_addr).await?;
+                bootstrap::adult(node, &comm, &mut connection_event_rx, bootstrap_addr).await?;
             let state = Approved::new(node, section, None, event_tx);
 
             (state, comm, backlog)

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -33,9 +33,8 @@ use crate::{
     messages::{Message, PING},
     node::Node,
     peer::Peer,
-    relocation::STARTUP_PHASE_AGE_RANGE,
     section::{EldersInfo, SectionProofChain},
-    TransportConfig,
+    TransportConfig, MIN_AGE,
 };
 use bytes::Bytes;
 use ed25519_dalek::{Keypair, PublicKey, Signature, Signer};
@@ -96,8 +95,7 @@ impl Routing {
         let (state, comm, backlog) = if config.first {
             info!("{} Starting a new network as the seed node.", node_name);
             let comm = Comm::new(config.transport_config, connection_event_tx)?;
-            let node = Node::new(keypair, comm.our_connection_info().await?)
-                .with_age(STARTUP_PHASE_AGE_RANGE.end);
+            let node = Node::new(keypair, comm.our_connection_info().await?).with_age(MIN_AGE + 1);
             let state = Approved::first_node(node, event_tx)?;
 
             state.send_event(Event::PromotedToElder);

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -107,7 +107,7 @@ impl Routing {
                 Comm::bootstrap(config.transport_config, connection_event_tx).await?;
             let node = Node::new(keypair, comm.our_connection_info().await?);
             let (node, section, backlog) =
-                bootstrap::adult(node, &comm, &mut connection_event_rx, bootstrap_addr).await?;
+                bootstrap::initial(node, &comm, &mut connection_event_rx, bootstrap_addr).await?;
             let state = Approved::new(node, section, None, event_tx);
 
             (state, comm, backlog)

--- a/src/routing/tests/mod.rs
+++ b/src/routing/tests/mod.rs
@@ -17,8 +17,7 @@ use crate::{
     location::DstLocation,
     majority,
     messages::{
-        BootstrapResponse, JoinRequest, Message, PlainMessage, Proof as ResourceProofingProof,
-        Variant,
+        BootstrapResponse, JoinRequest, Message, PlainMessage, ResourceProofResponse, Variant,
     },
     network::Network,
     node::Node,
@@ -97,7 +96,7 @@ async fn receive_join_request() -> Result<()> {
         Variant::JoinRequest(Box::new(JoinRequest {
             section_key,
             relocate_payload: None,
-            proof: None,
+            resource_proof_response: None,
         })),
         None,
         None,
@@ -116,9 +115,9 @@ async fn receive_join_request() -> Result<()> {
     );
     let response_message = Message::from_bytes(&response_message)?;
 
-    let (nonce, signature) = assert_matches!(
+    let (nonce, nonce_signature) = assert_matches!(
         response_message.variant(),
-        Variant::Challenge { nonce, signature, .. } => (*nonce, *signature)
+        Variant::ResourceChallenge { nonce, nonce_signature, .. } => (*nonce, *nonce_signature)
     );
 
     let rp = ResourceProof::new(RESOURCE_PROOF_DATA_SIZE, RESOURCE_PROOF_DIFFICULTY);
@@ -132,11 +131,11 @@ async fn receive_join_request() -> Result<()> {
         Variant::JoinRequest(Box::new(JoinRequest {
             section_key,
             relocate_payload: None,
-            proof: Some(ResourceProofingProof {
+            resource_proof_response: Some(ResourceProofResponse {
                 solution,
                 data,
                 nonce,
-                signature,
+                nonce_signature,
             }),
         })),
         None,

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -214,11 +214,6 @@ impl Section {
         }
     }
 
-    /// Returns whether the given peer adult or elder.
-    pub fn is_adult_or_elder(&self, name: &XorName) -> bool {
-        self.members.is_mature(name) || self.is_elder(name)
-    }
-
     // Prefix of our section.
     pub fn prefix(&self) -> &Prefix {
         &self.elders_info().prefix

--- a/src/section/section_peers.rs
+++ b/src/section/section_peers.rs
@@ -92,11 +92,6 @@ impl SectionPeers {
             .unwrap_or(false)
     }
 
-    /// Returns whether the given peer is known to us (joined or left)
-    pub fn is_known(&self, name: &XorName) -> bool {
-        self.members.contains_key(name)
-    }
-
     /// Update a member of our section.
     /// Returns whether anything actually changed.
     pub fn update(&mut self, new_info: Proven<MemberInfo>) -> bool {

--- a/src/section/section_peers.rs
+++ b/src/section/section_peers.rs
@@ -92,14 +92,6 @@ impl SectionPeers {
             .unwrap_or(false)
     }
 
-    /// Returns whether the given peer is joined and has age > MIN_AGE.
-    pub fn is_mature(&self, name: &XorName) -> bool {
-        self.members
-            .get(name)
-            .map(|info| info.value.state == PeerState::Joined && info.value.is_mature())
-            .unwrap_or(false)
-    }
-
     /// Returns whether the given peer is known to us (joined or left)
     pub fn is_known(&self, name: &XorName) -> bool {
         self.members.contains_key(name)

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -97,9 +97,7 @@ async fn test_startup_section_bootstrapping() -> Result<()> {
             let (node, mut event_stream) =
                 create_node(config_with_contact(genesis_contact)).await?;
 
-            // During the startup phase, joining nodes are instantly relocated.
-            assert_next_event!(event_stream, Event::RelocationStarted { .. });
-            assert_next_event!(event_stream, Event::Relocated { .. });
+            assert_event!(event_stream, Event::PromotedToElder);
 
             Ok::<_, Error>(node)
         })

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -18,11 +18,8 @@ async fn test_node_drop() -> Result<()> {
     // majority and the `Offline` votes accumulate.
     let mut nodes = create_connected_nodes(3).await?;
 
-    // We are in the startup phase, so the second and third node are instantly relocated.
-    // Let's wait until they re-join.
     for (_, events) in &mut nodes[1..] {
-        assert_next_event!(events, Event::RelocationStarted { .. });
-        assert_next_event!(events, Event::Relocated { .. });
+        assert_event!(events, Event::PromotedToElder);
     }
 
     // Wait for the DKG(s) to complete, to make sure there are no more messages being exchanged

--- a/tests/messages.rs
+++ b/tests/messages.rs
@@ -92,9 +92,7 @@ async fn test_messages_between_nodes() -> Result<()> {
     // start a second node which sends a message to the first node
     let (node2, mut event_stream) = create_node(config_with_contact(node1_contact)).await?;
 
-    // We are in the startup phase, so node2 is instantly relocated. Let's wait until it re-joins.
-    assert_next_event!(event_stream, Event::RelocationStarted { .. });
-    assert_next_event!(event_stream, Event::Relocated { .. });
+    assert_event!(event_stream, Event::PromotedToElder);
 
     let node2_name = node2.name().await;
 


### PR DESCRIPTION
This PR contains the work of using resource_proofing to challenge the joining node so that any joined node can now be considered as an adult immediately.