### PR TITLE
Do not require resource proof from relocated nodes + bugfixes

### DIFF
--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -478,16 +478,13 @@ impl Approved {
                     }
                 }
             }
-            Variant::ResourceChallenge { .. } => {
-                // Already approved, no need to resolve challenge.
-                return Ok(MessageStatus::Useless);
-            }
             Variant::Sync { .. }
             | Variant::Relocate(_)
             | Variant::BootstrapRequest(_)
             | Variant::BouncedUntrustedMessage(_)
             | Variant::BouncedUnknownMessage { .. }
-            | Variant::DKGMessage { .. } => {}
+            | Variant::DKGMessage { .. }
+            | Variant::ResourceChallenge { .. } => {}
         }
 
         if self.verify_message(msg)? {
@@ -579,7 +576,9 @@ impl Approved {
                 commands.extend(result?);
                 Ok(commands)
             }
-            Variant::NodeApproval(_) | Variant::BootstrapResponse(_) => {
+            Variant::NodeApproval(_)
+            | Variant::BootstrapResponse(_)
+            | Variant::ResourceChallenge { .. } => {
                 if let Some(RelocateState::InProgress(message_tx)) = &mut self.relocate_state {
                     if let Some(sender) = sender {
                         trace!("Forwarding {:?} to the bootstrap task", msg);
@@ -589,10 +588,6 @@ impl Approved {
                     }
                 }
 
-                Ok(vec![])
-            }
-            Variant::ResourceChallenge { .. } => {
-                trace!("Already got approved to join, no need to resolve challenge");
                 Ok(vec![])
             }
         }

--- a/tests/bootstrap.rs
+++ b/tests/bootstrap.rs
@@ -12,6 +12,8 @@ use anyhow::{Error, Result};
 use ed25519_dalek::Keypair;
 use futures::future;
 use sn_routing::{Config, Event, ELDER_SIZE};
+use std::collections::HashSet;
+use tokio::time;
 use utils::*;
 
 #[tokio::test]
@@ -66,6 +68,7 @@ async fn test_node_bootstrapping() -> Result<()> {
 
 #[tokio::test]
 async fn test_startup_section_bootstrapping() -> Result<()> {
+    // Create the genesis node.
     let (genesis_node, mut event_stream) = create_node(Config {
         first: true,
         ..Default::default()
@@ -73,51 +76,39 @@ async fn test_startup_section_bootstrapping() -> Result<()> {
     .await?;
     let other_node_count = ELDER_SIZE - 1;
 
-    // spawn genesis node events listener
-    let genesis_handler = tokio::spawn(async move {
-        let mut joined_nodes = vec![];
-        // expect events for all nodes
-        while let Some(event) = event_stream.next().await {
-            if let Event::MemberJoined { name, .. } = event {
-                joined_nodes.push(name)
-            }
-
-            if joined_nodes.len() == other_node_count {
-                break;
-            }
-        }
-
-        joined_nodes
-    });
-
-    // bootstrap several nodes with genesis to form a section
+    // Then add more nodes to form a section. Because there is only `ELDER_SIZE` nodes in total,
+    // we expect every one to be promoted to elder.
     let genesis_contact = genesis_node.our_connection_info().await?;
-    let nodes_joining_tasks: Vec<_> = (0..other_node_count)
-        .map(|_| async {
-            let (node, mut event_stream) =
-                create_node(config_with_contact(genesis_contact)).await?;
+    let nodes_joining_tasks = (0..other_node_count).map(|_| async {
+        let (node, mut event_stream) = create_node(config_with_contact(genesis_contact)).await?;
+        assert_event!(event_stream, Event::PromotedToElder);
+        Ok::<_, Error>(node)
+    });
+    let other_nodes = future::try_join_all(nodes_joining_tasks).await?;
 
-            assert_event!(event_stream, Event::PromotedToElder);
+    // Keep track of the joined nodes the genesis node knows about.
+    let mut joined_names = HashSet::new();
 
-            Ok::<_, Error>(node)
-        })
-        .collect();
+    // Keep listening to the events from the genesis node until it becomes aware of all the other
+    // nodes in the section.
+    while let Some(event) = time::timeout(TIMEOUT, event_stream.next()).await? {
+        let _ = match event {
+            Event::MemberJoined { name, .. } => joined_names.insert(name),
+            Event::MemberLeft { name, .. } => joined_names.remove(&name),
+            _ => false,
+        };
 
-    let nodes = future::try_join_all(nodes_joining_tasks).await?;
+        let actual_names: HashSet<_> = future::join_all(other_nodes.iter().map(|node| node.name()))
+            .await
+            .into_iter()
+            .collect();
 
-    // just await for genesis node to finish receiving all events
-    let joined_nodes = genesis_handler.await?;
-
-    for node in nodes {
-        let name = node.name().await;
-
-        // assert names of nodes joined match
-        assert!(joined_nodes.contains(&name));
-
-        verify_invariants_for_node(&node, ELDER_SIZE).await?;
+        if joined_names == actual_names {
+            return Ok(());
+        }
     }
 
-    Ok(())
+    panic!("event stream unexpectedly closed")
 }
 
 // Test that the first `ELDER_SIZE` nodes in the network are promoted to elders.


### PR DESCRIPTION
- Do not require resource proof from relocated nodes
- Add test for handling join request from relocated node
- Fix incorrect test assertion that a newly joined node is never instantly relocated
- Forward `ResourceChallenge` to the bootstrap task (not necessary, but good future proofing)
- Refactor `handle_join_request` by extracting the resource proof logic into separate methods
- Fix a bug with section update being permanently blocked when there is only one elder and he wants to demote himself and promote another single node
- Fix a bug with promotion being blocked when all the current elders are being relocated and there is fewer than `ELDER_SIZE` other joined nodes in the section
- Fix the `test_startup_section_bootstrapping` test by taking relocations into account.