### PR TITLE
Log with the tracing crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ err-derive = "~0.2.4"
 futures = "~0.3.6"
 hex_fmt = "~0.3.0"
 itertools = "~0.9.0"
-log = "~0.4.8"
 lru_time_cache = "~0.11.0"
 qp2p = "~0.9.1"
 rand = "~0.7.3"
@@ -47,12 +46,17 @@ resource_proof = "0.8.0"
   version = "~0.2.22"
   features = [ "sync", "time", "rt-util" ]
 
+  [dependencies.tracing]
+  version = "~0.1.22"
+  default-features = false
+  features = ["log", "std"]
+
 [dev-dependencies]
 anyhow = "1"
 assert_matches = "1.3"
-env_logger = "~0.7.1"
-structopt = "~0.3.17"
 proptest = "0.10.1"
+structopt = "~0.3.17"
+tracing-subscriber = "~0.2.15"
 
   [dev-dependencies.rand]
   version = "~0.7.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 )]
 
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 // ############################################################################
 // Public API

--- a/src/network/stats.rs
+++ b/src/network/stats.rs
@@ -6,8 +6,6 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-use std::{cmp, iter};
-
 pub struct NetworkStats {
     pub(super) known_elders: u64,
     pub(super) total_elders: u64,
@@ -16,21 +14,13 @@ pub struct NetworkStats {
 
 impl NetworkStats {
     pub fn print(&self) {
-        const LEVEL: log::Level = log::Level::Info;
-
-        if log::log_enabled!(LEVEL) {
-            let status_str = format!("Known elders: {:3}", self.known_elders);
-            let network_estimate = if self.total_elders_exact {
-                format!("Exact total network elders: {}", self.total_elders)
-            } else {
-                format!("Estimated total network elders: {}", self.total_elders)
-            };
-            let sep_len = cmp::max(status_str.len(), network_estimate.len());
-            let sep_str = iter::repeat('-').take(sep_len).collect::<String>();
-            log!(target: "stats", LEVEL, " -{}- ", sep_str);
-            log!(target: "stats", LEVEL, "| {:<1$} |", status_str, sep_len);
-            log!(target: "stats", LEVEL, "| {:<1$} |", network_estimate, sep_len);
-            log!(target: "stats", LEVEL, " -{}- ", sep_str);
+        if self.total_elders_exact {
+            info!("*** Exact total network elders: {} ***", self.known_elders)
+        } else {
+            info!(
+                "*** Known network elders: {}, Estimated total network elders: {} ***",
+                self.known_elders, self.total_elders
+            )
         }
     }
 }

--- a/src/routing/stage.rs
+++ b/src/routing/stage.rs
@@ -14,6 +14,7 @@ use tokio::{
     sync::{mpsc, watch, Mutex},
     time,
 };
+use tracing::Instrument;
 
 // Node's current stage which is responsible
 // for accessing current info and trigger operations.
@@ -58,84 +59,30 @@ impl Stage {
 
     /// Handles a single command.
     pub async fn handle_command(&self, command: Command) -> Result<Vec<Command>> {
-        trace!("Handling command {:?}", command);
+        // Create a tracing span containing info about the current node. This is very useful when
+        // analyzing logs produced by running multiple nodes within the same process, for example
+        // from integration tests.
+        let span = {
+            let state = self.state.lock().await;
+            trace_span!(
+                "handle_command",
+                name = %state.node().name(),
+                prefix = format_args!("({:b})", state.section().prefix()),
+                age = state.node().age,
+                elder = state.is_elder(),
+            )
+        };
 
-        let result = async {
-            match command {
-                Command::HandleMessage { message, sender } => {
-                    self.state
-                        .lock()
-                        .await
-                        .handle_message(sender, message)
-                        .await
-                }
-                Command::HandleTimeout(token) => self.state.lock().await.handle_timeout(token),
-                Command::HandleVote { vote, proof_share } => {
-                    self.state.lock().await.handle_vote(vote, proof_share)
-                }
-                Command::HandleConsensus { vote, proof } => {
-                    self.state.lock().await.handle_consensus(vote, proof)
-                }
-                Command::HandleConnectionLost(addr) => Ok(self
-                    .state
-                    .lock()
-                    .await
-                    .handle_connection_lost(&addr)
-                    .into_iter()
-                    .collect()),
-                Command::HandlePeerLost(addr) => self.state.lock().await.handle_peer_lost(&addr),
-                Command::HandleDkgParticipationResult {
-                    dkg_key,
-                    elders_info,
-                    result,
-                } => self.state.lock().await.handle_dkg_participation_result(
-                    dkg_key,
-                    elders_info,
-                    result,
-                ),
-                Command::HandleDkgObservationResult {
-                    elders_info,
-                    result,
-                } => self
-                    .state
-                    .lock()
-                    .await
-                    .handle_dkg_observation_result(elders_info, result),
-                Command::SendMessage {
-                    recipients,
-                    delivery_group_size,
-                    message,
-                } => Ok(self
-                    .send_message(&recipients, delivery_group_size, message)
-                    .await),
-                Command::SendUserMessage { src, dst, content } => {
-                    self.state.lock().await.send_user_message(src, dst, content)
-                }
-                Command::ScheduleTimeout { duration, token } => Ok(self
-                    .handle_schedule_timeout(duration, token)
-                    .await
-                    .into_iter()
-                    .collect()),
-                Command::Relocate {
-                    bootstrap_addrs,
-                    details,
-                    message_rx,
-                } => {
-                    self.handle_relocate(bootstrap_addrs, details, message_rx)
-                        .await
-                }
-                Command::SetJoinsAllowed(joins_allowed) => {
-                    self.state.lock().await.set_joins_allowed(joins_allowed)
-                }
-            }
+        async {
+            trace!(?command);
+
+            self.try_handle_command(command).await.map_err(|error| {
+                error!("Error encountered when handling command: {}", error);
+                error
+            })
         }
-        .await;
-
-        if let Err(error) = &result {
-            error!("Error encountered when handling command: {}", error);
-        }
-
-        result
+        .instrument(span)
+        .await
     }
 
     // Terminate this routing instance - cancel all scheduled timers including any future ones,
@@ -143,6 +90,76 @@ impl Stage {
     pub fn terminate(&self) {
         let _ = self.cancel_timer_tx.broadcast(true);
         self.comm.terminate()
+    }
+
+    async fn try_handle_command(&self, command: Command) -> Result<Vec<Command>> {
+        match command {
+            Command::HandleMessage { message, sender } => {
+                self.state
+                    .lock()
+                    .await
+                    .handle_message(sender, message)
+                    .await
+            }
+            Command::HandleTimeout(token) => self.state.lock().await.handle_timeout(token),
+            Command::HandleVote { vote, proof_share } => {
+                self.state.lock().await.handle_vote(vote, proof_share)
+            }
+            Command::HandleConsensus { vote, proof } => {
+                self.state.lock().await.handle_consensus(vote, proof)
+            }
+            Command::HandleConnectionLost(addr) => Ok(self
+                .state
+                .lock()
+                .await
+                .handle_connection_lost(&addr)
+                .into_iter()
+                .collect()),
+            Command::HandlePeerLost(addr) => self.state.lock().await.handle_peer_lost(&addr),
+            Command::HandleDkgParticipationResult {
+                dkg_key,
+                elders_info,
+                result,
+            } => self.state.lock().await.handle_dkg_participation_result(
+                dkg_key,
+                elders_info,
+                result,
+            ),
+            Command::HandleDkgObservationResult {
+                elders_info,
+                result,
+            } => self
+                .state
+                .lock()
+                .await
+                .handle_dkg_observation_result(elders_info, result),
+            Command::SendMessage {
+                recipients,
+                delivery_group_size,
+                message,
+            } => Ok(self
+                .send_message(&recipients, delivery_group_size, message)
+                .await),
+            Command::SendUserMessage { src, dst, content } => {
+                self.state.lock().await.send_user_message(src, dst, content)
+            }
+            Command::ScheduleTimeout { duration, token } => Ok(self
+                .handle_schedule_timeout(duration, token)
+                .await
+                .into_iter()
+                .collect()),
+            Command::Relocate {
+                bootstrap_addrs,
+                details,
+                message_rx,
+            } => {
+                self.handle_relocate(bootstrap_addrs, details, message_rx)
+                    .await
+            }
+            Command::SetJoinsAllowed(joins_allowed) => {
+                self.state.lock().await.set_joins_allowed(joins_allowed)
+            }
+        }
     }
 
     // Note: this indirecton is needed. Trying to call `spawn(self.handle_commands(...))` directly

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -40,7 +40,7 @@ async fn test_node_drop() -> Result<()> {
     let dropped_addr = dropped_node.our_connection_info().await?;
     drop(dropped_node);
 
-    log::info!("Dropped {} at {}", dropped_name, dropped_addr);
+    tracing::info!("Dropped {} at {}", dropped_name, dropped_addr);
 
     for (_, events) in &mut nodes {
         assert_event!(events, Event::MemberLeft { name, .. } if name == dropped_name)


### PR DESCRIPTION
Use [`tracing`](https://docs.rs/tracing/0.1.22/tracing/) for logging instead of the `log` crate. This allows us to use structured logging and spans. There should be no change necessary on the consumers of this crate as `tracing` is compatible with `log`. 