### PR TITLE
chore(ci): add cargo deny check to CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -111,6 +111,17 @@ jobs:
           cargo install cargo-udeps --locked
           cargo +nightly udeps --all-targets
 
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # wget the shared deny.toml file from the QA repo
+    - shell: bash
+      run: wget https://raw.githubusercontent.com/maidsafe/QA/master/misc-scripts/deny.toml
+
+    - uses: EmbarkStudios/cargo-deny-action@v1
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.2.1"
-bls_dkg = "~0.2.0"
+bls_dkg = "~0.3.1"
 bls_signature_aggregator = "~0.1.4"
 bytes = "~0.5.4"
 futures = "~0.3.6"

--- a/tests/messages.rs
+++ b/tests/messages.rs
@@ -11,7 +11,7 @@ mod utils;
 use anyhow::{format_err, Result};
 use bytes::Bytes;
 use qp2p::QuicP2p;
-use sn_routing::{Config, DstLocation, Error, Event, SrcLocation, TransportConfig};
+use sn_routing::{Config, DstLocation, Error, Event, SrcLocation};
 use std::net::{IpAddr, Ipv4Addr};
 use utils::*;
 
@@ -45,7 +45,10 @@ async fn test_messages_client_node() -> Result<()> {
 
     // create a client which sends a message to the node
     let node_addr = node.our_connection_info().await?;
-    let mut config = TransportConfig::default();
+    let mut config = sn_routing::TransportConfig {
+        ip: Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+        ..Default::default()
+    };
     config.ip = Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
 
     let client = QuicP2p::with_config(Some(config), &[node_addr], false)?;


### PR DESCRIPTION
This fetches a shared deny.toml from the QA repo before running the cargo deny GH Action.