### PR TITLE
Run cargo intraconv to change markdown link to intra-doc link

### DIFF
--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -70,7 +70,7 @@ impl Default for Config {
 /// A node is a part of the network that can route messages and be a member of a section or group
 /// location. Its methods can be used to send requests and responses as either an individual
 /// `Node` or as a part of a section or group location. Their `src` argument indicates that
-/// role, and can be any [`SrcLocation`](enum.SrcLocation.html).
+/// role, and can be any [`SrcLocation`].
 pub struct Routing {
     stage: Arc<Stage>,
 }


### PR DESCRIPTION
Run cargo intraconv to change markdown link to intra-doc link.
Originally this PR also added `cargo deadlinks` scan to CI but there were several broken doc links from external deps so would have been too much noise - removed that commit.