### PR TITLE
Various churn related fixes

### DIFF
--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -536,9 +536,9 @@ impl Network {
         );
         println!(
             "{:18} {}",
-            self.theme.label.paint("sections:"),
+            self.theme.label.paint("section members:"),
             sections
-                .into_iter()
+                .iter()
                 .format_with(", ", |(prefix, count), f| f(&format_args!(
                     "({:b}): {}",
                     prefix,
@@ -551,6 +551,7 @@ impl Network {
             self.theme.label.paint("section health:"),
             self.probe_tracker
                 .status()
+                .filter(|(prefix, ..)| sections.contains_key(prefix))
                 .format_with(", ", |(prefix, delivered, sent), f| {
                     let percent = percent(delivered, sent);
 
@@ -559,7 +560,7 @@ impl Network {
                         prefix,
                         self.theme
                             .health(percent)
-                            .paint(format_args!("{:.1}%", percent)),
+                            .paint(format_args!("{:.0}%", percent)),
                     ))
                 })
         );
@@ -575,12 +576,12 @@ impl Network {
             self.theme.label.paint("churn:"),
             self.theme.value.paint(self.stats.join_attempts),
             self.theme.value.paint(format_args!(
-                "{} ({:.1}%)",
+                "{} ({:.0}%)",
                 self.stats.join_successes,
                 percent(self.stats.join_successes, self.stats.join_attempts)
             )),
             failure_style.paint(format_args!(
-                "{} ({:.1}%)",
+                "{} ({:.0}%)",
                 self.stats.join_failures,
                 percent(self.stats.join_failures, self.stats.join_attempts)
             )),
@@ -592,7 +593,7 @@ impl Network {
             self.theme.label.paint("relocations:"),
             self.theme.value.paint(self.stats.relocation_attempts),
             self.theme.value.paint(format_args!(
-                "{} ({:.1}%)",
+                "{} ({:.0}%)",
                 self.stats.relocation_successes,
                 percent(
                     self.stats.relocation_successes,

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -456,7 +456,7 @@ impl Network {
             .await
         {
             Ok(()) => Ok(true),
-            Err(RoutingError::InvalidSource) => Ok(false), // node name changed
+            Err(RoutingError::InvalidSrcLocation) => Ok(false), // node name changed
             Err(error) => Err(error.into()),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,8 +15,6 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
-    #[error("Invalid requester or handler locations.")]
-    BadLocation,
     #[error("Failed signature check.")]
     FailedSignature,
     #[error("Cannot route.")]
@@ -27,10 +25,10 @@ pub enum Error {
     InvalidState,
     #[error("Bincode error: {}", .0)]
     Bincode(#[from] bincode::Error),
-    #[error("Invalid source.")]
-    InvalidSource,
-    #[error("Invalid destination.")]
-    InvalidDestination,
+    #[error("Invalid source location.")]
+    InvalidSrcLocation,
+    #[error("Invalid destination location.")]
+    InvalidDstLocation,
     #[error("Content of a received message is inconsistent.")]
     InvalidMessage,
     #[error("A signature share is invalid.")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,11 +21,11 @@ pub enum Error {
     FailedSignature,
     #[error("Cannot route.")]
     CannotRoute,
-    #[error("Network layer error: {}", _0)]
+    #[error("Network layer error: {}", .0)]
     Network(#[from] qp2p::Error),
     #[error("The node is not in a state to handle the action.")]
     InvalidState,
-    #[error("Bincode error: {}", _0)]
+    #[error("Bincode error: {}", .0)]
     Bincode(#[from] bincode::Error),
     #[error("Invalid source.")]
     InvalidSource,

--- a/src/location.rs
+++ b/src/location.rs
@@ -70,7 +70,7 @@ impl DstLocation {
     pub(crate) fn as_node(&self) -> Result<&XorName> {
         match self {
             Self::Node(name) => Ok(name),
-            Self::Section(_) | Self::Direct => Err(Error::BadLocation),
+            Self::Section(_) | Self::Direct => Err(Error::InvalidDstLocation),
         }
     }
 
@@ -78,7 +78,7 @@ impl DstLocation {
     pub(crate) fn check_is_section(&self) -> Result<()> {
         match self {
             Self::Section(_) => Ok(()),
-            Self::Node(_) | Self::Direct => Err(Error::BadLocation),
+            Self::Node(_) | Self::Direct => Err(Error::InvalidDstLocation),
         }
     }
 

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -337,7 +337,7 @@ pub enum MessageStatus {
 
 #[derive(Debug, Error)]
 pub enum CreateError {
-    #[error("bincode error: {}", _0)]
+    #[error("bincode error: {}", .0)]
     Bincode(#[from] bincode::Error),
     #[error("signature check failed")]
     FailedSignature,
@@ -357,9 +357,9 @@ impl From<CreateError> for Error {
 pub enum ExtendProofChainError {
     #[error("message has no proof chain")]
     NoProofChain,
-    #[error("failed to extend proof chain: {}", _0)]
+    #[error("failed to extend proof chain: {}", .0)]
     Extend(#[from] ExtendError),
-    #[error("failed to re-create message: {}", _0)]
+    #[error("failed to re-create message: {}", .0)]
     Create(#[from] CreateError),
 }
 

--- a/src/messages/src_authority.rs
+++ b/src/messages/src_authority.rs
@@ -54,7 +54,7 @@ impl SrcAuthority {
         if self.is_section() {
             Ok(())
         } else {
-            Err(Error::BadLocation)
+            Err(Error::InvalidSrcLocation)
         }
     }
 
@@ -65,14 +65,14 @@ impl SrcAuthority {
     pub(crate) fn to_node_name(&self) -> Result<XorName> {
         match self {
             Self::Node { public_key, .. } => Ok(name(public_key)),
-            Self::Section { .. } => Err(Error::BadLocation),
+            Self::Section { .. } => Err(Error::InvalidSrcLocation),
         }
     }
 
     // If this location is `Node`, returns the corresponding `Peer` with `addr`. Otherwise error.
     pub(crate) fn to_node_peer(&self, addr: SocketAddr) -> Result<Peer> {
         match self {
-            Self::Section { .. } => Err(Error::BadLocation),
+            Self::Section { .. } => Err(Error::InvalidSrcLocation),
             Self::Node {
                 public_key, age, ..
             } => Ok(Peer::new(name(public_key), addr, *age)),
@@ -83,7 +83,7 @@ impl SrcAuthority {
     pub(crate) fn as_section_prefix(&self) -> Result<&Prefix> {
         match self {
             Self::Section { prefix, .. } => Ok(prefix),
-            Self::Node { .. } => Err(Error::BadLocation),
+            Self::Node { .. } => Err(Error::InvalidSrcLocation),
         }
     }
 }

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -86,6 +86,8 @@ pub(crate) enum Variant {
         dkg_key: DkgKey,
         /// The DKG particpants.
         elders_info: EldersInfo,
+        /// The section chain index of the key to be generated.
+        key_index: u64,
     },
     /// Message exchanged for DKG process.
     DKGMessage {
@@ -199,10 +201,12 @@ impl Debug for Variant {
             Self::DKGStart {
                 dkg_key,
                 elders_info,
+                key_index,
             } => f
                 .debug_struct("DKGStart")
                 .field("dkg_key", dkg_key)
                 .field("elders_info", elders_info)
+                .field("key_index", key_index)
                 .finish(),
             Self::DKGMessage { dkg_key, message } => f
                 .debug_struct("DKGMessage")

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -168,17 +168,13 @@ pub(crate) struct RelocatePayload {
 }
 
 impl RelocatePayload {
-    pub fn new(
-        details: SignedRelocateDetails,
-        new_name: &XorName,
-        old_keypair: &Keypair,
-    ) -> Result<Self, Error> {
+    pub fn new(details: SignedRelocateDetails, new_name: &XorName, old_keypair: &Keypair) -> Self {
         let signature_of_new_name_with_old_key = crypto::sign(&new_name.0, old_keypair);
 
-        Ok(Self {
+        Self {
             details,
             signature_of_new_name_with_old_key,
-        })
+        }
     }
 
     pub fn verify_identity(&self, new_name: &XorName) -> bool {

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -532,7 +532,8 @@ impl Approved {
             Variant::DKGStart {
                 dkg_key,
                 elders_info,
-            } => self.handle_dkg_start(*dkg_key, elders_info.clone()),
+                key_index,
+            } => self.handle_dkg_start(*dkg_key, elders_info.clone(), *key_index),
             Variant::DKGMessage { dkg_key, message } => {
                 self.handle_dkg_message(*dkg_key, message.clone(), msg.src().to_node_name()?)
             }
@@ -1097,10 +1098,11 @@ impl Approved {
         &mut self,
         dkg_key: DkgKey,
         new_elders_info: EldersInfo,
+        key_index: u64,
     ) -> Result<Vec<Command>> {
         trace!("Received DKGStart for {}", new_elders_info);
         self.dkg_voter
-            .start(&self.node.keypair, dkg_key, new_elders_info)
+            .start(&self.node.keypair, dkg_key, new_elders_info, key_index)
             .into_commands(&self.node)
     }
 
@@ -1742,6 +1744,7 @@ impl Approved {
         let variant = Variant::DKGStart {
             dkg_key,
             elders_info,
+            key_index: self.section.chain().last_key_index() + 1,
         };
         let vote = self.create_send_message_vote(DstLocation::Direct, variant, None)?;
         self.send_vote(recipients, vote)

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -837,14 +837,21 @@ impl Approved {
         }
 
         debug!(
-            "Received Relocate message to join the section at {}.",
+            "Received Relocate message to join the section at {}",
             details.relocate_details().destination
         );
 
-        if self.relocate_state.is_none() {
-            self.send_event(Event::RelocationStarted {
-                previous_name: self.node.name(),
-            });
+        match self.relocate_state {
+            Some(RelocateState::InProgress(_)) => {
+                trace!("Ignore Relocate - relocation already in progress");
+                return None;
+            }
+            Some(RelocateState::Delayed(_)) => (),
+            None => {
+                self.send_event(Event::RelocationStarted {
+                    previous_name: self.node.name(),
+                });
+            }
         }
 
         let (message_tx, message_rx) = mpsc::channel(1);

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -1793,7 +1793,7 @@ impl Approved {
                 "Not sending user message {:?} -> {:?}: not part of the source location",
                 src, dst
             );
-            return Err(Error::BadLocation);
+            return Err(Error::InvalidSource);
         }
 
         if matches!(dst, DstLocation::Direct) {
@@ -1801,7 +1801,7 @@ impl Approved {
                 "Not sending user message {:?} -> {:?}: direct dst not supported",
                 src, dst
             );
-            return Err(Error::BadLocation);
+            return Err(Error::InvalidDestination);
         }
 
         let variant = Variant::UserMessage(content);

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -1113,7 +1113,7 @@ impl Approved {
         trace!("handle DKG message {:?} from {}", message, sender);
 
         self.dkg_voter
-            .process_message(&self.node.keypair, dkg_key, message)
+            .process_message(&self.node.keypair, &dkg_key, message)
             .into_commands(&self.node)
     }
 
@@ -1123,7 +1123,7 @@ impl Approved {
         proof: DkgFailureProof,
     ) -> Result<Vec<Command>> {
         self.dkg_voter
-            .process_failure(dkg_key, proof)
+            .process_failure(&dkg_key, proof)
             .into_commands(&self.node)
     }
 

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -1454,13 +1454,16 @@ impl Approved {
                 sibling.section.elders_info()
             );
 
-            // We can update the sibling knowledge already because we know they also reached consensus
-            // on our `OurKey` so they know our latest key. Need to vote for it first though, to
-            // accumulate the signatures.
-            commands.extend(self.vote(Vote::TheirKnowledge {
-                prefix: *sibling.section.prefix(),
-                key_index: self.section.chain().last_key_index(),
-            })?);
+            if self.is_elder() {
+                // We can update the sibling knowledge already because we know they also reached
+                // consensus on our `OurKey` so they know our latest key. Need to vote for it first
+                // though, to accumulate the signatures.
+                commands.extend(self.vote(Vote::TheirKnowledge {
+                    prefix: *sibling.section.prefix(),
+                    key_index: self.section.chain().last_key_index(),
+                })?);
+            }
+
             commands.extend(self.send_sync(sibling.section, sibling.network)?);
         }
 

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -495,7 +495,7 @@ impl Approved {
                 self.handle_relocate_promise(*promise, msg.to_bytes())
             }
             Variant::BootstrapRequest(name) => {
-                let sender = sender.ok_or(Error::InvalidSource)?;
+                let sender = sender.ok_or(Error::InvalidSrcLocation)?;
                 Ok(vec![self.handle_bootstrap_request(
                     msg.src().to_node_peer(sender)?,
                     *name,
@@ -503,7 +503,7 @@ impl Approved {
             }
 
             Variant::JoinRequest(join_request) => {
-                let sender = sender.ok_or(Error::InvalidSource)?;
+                let sender = sender.ok_or(Error::InvalidSrcLocation)?;
                 self.handle_join_request(msg.src().to_node_peer(sender)?, *join_request.clone())
             }
             Variant::UserMessage(content) => {
@@ -511,7 +511,7 @@ impl Approved {
                 Ok(vec![])
             }
             Variant::BouncedUntrustedMessage(message) => {
-                let sender = sender.ok_or(Error::InvalidSource)?;
+                let sender = sender.ok_or(Error::InvalidSrcLocation)?;
                 Ok(self
                     .handle_bounced_untrusted_message(
                         msg.src().to_node_peer(sender)?,
@@ -522,7 +522,7 @@ impl Approved {
                     .collect())
             }
             Variant::BouncedUnknownMessage { src_key, message } => {
-                let sender = sender.ok_or(Error::InvalidSource)?;
+                let sender = sender.ok_or(Error::InvalidSrcLocation)?;
                 self.handle_bounced_unknown_message(
                     msg.src().to_node_peer(sender)?,
                     message.clone(),
@@ -941,7 +941,7 @@ impl Approved {
             let conn_infos = section.peers().map(Peer::addr).copied().collect();
             BootstrapResponse::Rebootstrap(conn_infos)
         } else {
-            return Err(Error::InvalidDestination);
+            return Err(Error::InvalidDstLocation);
         };
 
         debug!("Sending BootstrapResponse {:?} to {}", response, peer);
@@ -1137,7 +1137,7 @@ impl Approved {
             .section
             .members()
             .get(sender)
-            .ok_or(Error::InvalidSource)?
+            .ok_or(Error::InvalidSrcLocation)?
             .peer;
 
         if !proofs.verify(&elders_info) {
@@ -1793,7 +1793,7 @@ impl Approved {
                 "Not sending user message {:?} -> {:?}: not part of the source location",
                 src, dst
             );
-            return Err(Error::InvalidSource);
+            return Err(Error::InvalidSrcLocation);
         }
 
         if matches!(dst, DstLocation::Direct) {
@@ -1801,7 +1801,7 @@ impl Approved {
                 "Not sending user message {:?} -> {:?}: direct dst not supported",
                 src, dst
             );
-            return Err(Error::InvalidDestination);
+            return Err(Error::InvalidDstLocation);
         }
 
         let variant = Variant::UserMessage(content);

--- a/src/routing/bootstrap.rs
+++ b/src/routing/bootstrap.rs
@@ -113,7 +113,7 @@ impl<'a> State<'a> {
             .await?;
 
         let relocate_payload = if let Some(details) = relocate_details {
-            Some(self.process_relocation(&elders_info, details)?)
+            Some(self.process_relocation(&elders_info, details))
         } else {
             None
         };
@@ -210,7 +210,7 @@ impl<'a> State<'a> {
         &mut self,
         elders_info: &EldersInfo,
         relocate_details: SignedRelocateDetails,
-    ) -> Result<RelocatePayload> {
+    ) -> RelocatePayload {
         // We are relocating so we need to change our name.
         // Use a name that will match the destination even after multiple splits
         let extra_split_count = 3;
@@ -223,12 +223,12 @@ impl<'a> State<'a> {
         let new_name = crypto::name(&new_keypair.public);
         let age = relocate_details.relocate_details().age;
         let relocate_payload =
-            RelocatePayload::new(relocate_details, &new_name, &self.node.keypair)?;
+            RelocatePayload::new(relocate_details, &new_name, &self.node.keypair);
 
         info!("{} Changing name to {}.", self.node, new_name);
         self.node = Node::new(new_keypair, self.node.addr).with_age(age);
 
-        Ok(relocate_payload)
+        relocate_payload
     }
 
     // Send `JoinRequest` and wait for the response. If the response is `Rejoin`, repeat with the

--- a/src/routing/bootstrap.rs
+++ b/src/routing/bootstrap.rs
@@ -146,11 +146,6 @@ impl<'a> State<'a> {
                     return Ok((elders_info, section_key));
                 }
                 BootstrapResponse::Rebootstrap(new_bootstrap_addrs) => {
-                    if new_bootstrap_addrs.is_empty() {
-                        error!("{} Invalid rebootstrap response: missing peers", self.node);
-                        return Err(Error::InvalidMessage);
-                    }
-
                     info!(
                         "{} Bootstrapping redirected to another set of peers: {:?}",
                         self.node, new_bootstrap_addrs,
@@ -190,6 +185,20 @@ impl<'a> State<'a> {
         while let Some((message, sender)) = self.recv_rx.next().await {
             match message.variant() {
                 Variant::BootstrapResponse(response) => {
+                    match response {
+                        BootstrapResponse::Rebootstrap(addrs) if addrs.is_empty() => {
+                            error!("Invalid Rebootstrap response: missing peers");
+                            continue;
+                        }
+                        BootstrapResponse::Join { elders_info, .. }
+                            if !elders_info.prefix.matches(&self.node.name()) =>
+                        {
+                            error!("Invalid Join response: bad prefix");
+                            continue;
+                        }
+                        BootstrapResponse::Join { .. } | BootstrapResponse::Rebootstrap(_) => (),
+                    }
+
                     if !self.verify_message(&message, None) {
                         continue;
                     }
@@ -528,8 +537,8 @@ mod tests {
     };
     use anyhow::{Error, Result};
     use assert_matches::assert_matches;
-    use futures::future;
-    use tokio::task;
+    use futures::future::{self, Either};
+    use tokio::{sync::mpsc::error::TryRecvError, task};
 
     #[tokio::test]
     async fn bootstrap_as_adult() -> Result<()> {
@@ -633,53 +642,269 @@ mod tests {
         let bootstrap_node = Node::new(crypto::gen_keypair(), gen_addr());
 
         let node = Node::new(crypto::gen_keypair(), gen_addr());
-        let state = State::new(node, send_tx, recv_rx)?;
+        let mut state = State::new(node, send_tx, recv_rx)?;
 
-        // Spawn the bootstrap task on a `LocalSet` so that it runs concurrently with the main test
-        // task, but is aborted when the test task finishes because we don't need it to complete
-        // for the purpose of this test.
-        let local_set = task::LocalSet::new();
+        let bootstrap_task = state.bootstrap(vec![bootstrap_node.addr], None);
+        let test_task = async {
+            task::yield_now().await;
 
-        let _ = local_set.spawn_local(state.run(vec![bootstrap_node.addr], None));
+            // Receive BootstrapRequest
+            let (bytes, recipients) = send_rx.try_recv()?;
+            let message = Message::from_bytes(&bytes)?;
 
-        local_set
-            .run_until(async {
-                task::yield_now().await;
+            assert_eq!(recipients, vec![bootstrap_node.addr]);
+            assert_matches!(message.variant(), Variant::BootstrapRequest(_));
 
-                // Receive BootstrapRequest
-                let (bytes, recipients) = send_rx.try_recv()?;
-                let message = Message::from_bytes(&bytes)?;
+            // Send Rebootstrap BootstrapResponse
+            let new_bootstrap_addrs: Vec<_> = (0..ELDER_SIZE).map(|_| gen_addr()).collect();
 
-                assert_eq!(recipients, vec![bootstrap_node.addr]);
-                assert_matches!(message.variant(), Variant::BootstrapRequest(_));
+            let message = Message::single_src(
+                &bootstrap_node,
+                DstLocation::Direct,
+                Variant::BootstrapResponse(BootstrapResponse::Rebootstrap(
+                    new_bootstrap_addrs.clone(),
+                )),
+                None,
+                None,
+            )?;
 
-                // Send Rebootstrap BootstrapResponse
-                let new_bootstrap_addrs: Vec<_> = (0..ELDER_SIZE).map(|_| gen_addr()).collect();
+            recv_tx.try_send((message, bootstrap_node.addr))?;
+            task::yield_now().await;
 
-                let message = Message::single_src(
-                    &bootstrap_node,
-                    DstLocation::Direct,
-                    Variant::BootstrapResponse(BootstrapResponse::Rebootstrap(
-                        new_bootstrap_addrs.clone(),
-                    )),
-                    None,
-                    None,
-                )?;
+            // Receive new BootstrapRequests
+            let (bytes, recipients) = send_rx.try_recv()?;
+            let message = Message::from_bytes(&bytes)?;
 
-                recv_tx.try_send((message, bootstrap_node.addr))?;
-                task::yield_now().await;
+            assert_eq!(recipients, new_bootstrap_addrs);
+            assert_matches!(message.variant(), Variant::BootstrapRequest(_));
 
-                // Receive new BootstrapRequests
-                let (bytes, recipients) = send_rx.try_recv()?;
-                let message = Message::from_bytes(&bytes)?;
+            Ok(())
+        };
 
-                assert_eq!(recipients, new_bootstrap_addrs);
-                assert_matches!(message.variant(), Variant::BootstrapRequest(_));
+        futures::pin_mut!(bootstrap_task);
+        futures::pin_mut!(test_task);
 
-                Ok(())
-            })
-            .await
+        match future::select(bootstrap_task, test_task).await {
+            Either::Left(_) => unreachable!(),
+            Either::Right((output, _)) => output,
+        }
     }
 
-    // TODO: add test for bootstrap as relocated node
+    #[tokio::test]
+    async fn invalid_bootstrap_response_rebootstrap() -> Result<()> {
+        let (send_tx, mut send_rx) = mpsc::channel(1);
+        let (mut recv_tx, recv_rx) = mpsc::channel(1);
+        let recv_rx = MessageReceiver::Deserialized(recv_rx);
+
+        let bootstrap_node = Node::new(crypto::gen_keypair(), gen_addr());
+
+        let node = Node::new(crypto::gen_keypair(), gen_addr());
+        let mut state = State::new(node, send_tx, recv_rx)?;
+
+        let bootstrap_task = state.bootstrap(vec![bootstrap_node.addr], None);
+        let test_task = async {
+            task::yield_now().await;
+
+            let (bytes, _) = send_rx.try_recv()?;
+            let message = Message::from_bytes(&bytes)?;
+            assert_matches!(message.variant(), Variant::BootstrapRequest(_));
+
+            let message = Message::single_src(
+                &bootstrap_node,
+                DstLocation::Direct,
+                Variant::BootstrapResponse(BootstrapResponse::Rebootstrap(vec![])),
+                None,
+                None,
+            )?;
+
+            recv_tx.try_send((message, bootstrap_node.addr))?;
+            task::yield_now().await;
+            assert_matches!(send_rx.try_recv(), Err(TryRecvError::Empty));
+
+            let addrs = (0..ELDER_SIZE).map(|_| gen_addr()).collect();
+            let message = Message::single_src(
+                &bootstrap_node,
+                DstLocation::Direct,
+                Variant::BootstrapResponse(BootstrapResponse::Rebootstrap(addrs)),
+                None,
+                None,
+            )?;
+
+            recv_tx.try_send((message, bootstrap_node.addr))?;
+            task::yield_now().await;
+
+            let (bytes, _) = send_rx.try_recv()?;
+            let message = Message::from_bytes(&bytes)?;
+            assert_matches!(message.variant(), Variant::BootstrapRequest(_));
+
+            Ok(())
+        };
+
+        futures::pin_mut!(bootstrap_task);
+        futures::pin_mut!(test_task);
+
+        match future::select(bootstrap_task, test_task).await {
+            Either::Left(_) => unreachable!(),
+            Either::Right((output, _)) => output,
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_bootstrap_response_join() -> Result<()> {
+        let (send_tx, mut send_rx) = mpsc::channel(1);
+        let (mut recv_tx, recv_rx) = mpsc::channel(1);
+        let recv_rx = MessageReceiver::Deserialized(recv_rx);
+
+        let bootstrap_node = Node::new(crypto::gen_keypair(), gen_addr());
+        let node = Node::new(crypto::gen_keypair(), gen_addr());
+
+        let (good_prefix, bad_prefix) = {
+            let p0 = Prefix::default().pushed(false);
+            let p1 = Prefix::default().pushed(true);
+
+            if node.name().bit(0) {
+                (p1, p0)
+            } else {
+                (p0, p1)
+            }
+        };
+
+        let mut state = State::new(node, send_tx, recv_rx)?;
+
+        let bootstrap_task = state.bootstrap(vec![bootstrap_node.addr], None);
+
+        // Send an invalid `BootstrapResponse::Join` followed by a valid one. The invalid one is
+        // ignored and the valid one processed normally.
+        let test_task = async {
+            task::yield_now().await;
+
+            let (bytes, _) = send_rx.try_recv()?;
+            let message = Message::from_bytes(&bytes)?;
+            assert_matches!(message.variant(), Variant::BootstrapRequest(_));
+
+            let (elders_info, _) = gen_elders_info(bad_prefix, ELDER_SIZE);
+            let section_key = bls::SecretKey::random().public_key();
+            let message = Message::single_src(
+                &bootstrap_node,
+                DstLocation::Direct,
+                Variant::BootstrapResponse(BootstrapResponse::Join {
+                    elders_info,
+                    section_key,
+                }),
+                None,
+                None,
+            )?;
+
+            recv_tx.try_send((message, bootstrap_node.addr))?;
+            task::yield_now().await;
+            assert_matches!(send_rx.try_recv(), Err(TryRecvError::Empty));
+
+            let (elders_info, _) = gen_elders_info(good_prefix, ELDER_SIZE);
+            let section_key = bls::SecretKey::random().public_key();
+            let message = Message::single_src(
+                &bootstrap_node,
+                DstLocation::Direct,
+                Variant::BootstrapResponse(BootstrapResponse::Join {
+                    elders_info,
+                    section_key,
+                }),
+                None,
+                None,
+            )?;
+
+            recv_tx.try_send((message, bootstrap_node.addr))?;
+
+            Ok(())
+        };
+
+        let (bootstrap_result, test_result) = future::join(bootstrap_task, test_task).await;
+        let _ = bootstrap_result?;
+        test_result
+    }
+
+    #[tokio::test]
+    async fn invalid_join_response_rejoin() -> Result<()> {
+        let (send_tx, mut send_rx) = mpsc::channel(1);
+        let (mut recv_tx, recv_rx) = mpsc::channel(1);
+        let recv_rx = MessageReceiver::Deserialized(recv_rx);
+
+        let bootstrap_node = Node::new(crypto::gen_keypair(), gen_addr());
+        let node = Node::new(crypto::gen_keypair(), gen_addr());
+
+        let (good_prefix, bad_prefix) = {
+            let p0 = Prefix::default().pushed(false);
+            let p1 = Prefix::default().pushed(true);
+
+            if node.name().bit(0) {
+                (p1, p0)
+            } else {
+                (p0, p1)
+            }
+        };
+
+        let state = State::new(node, send_tx, recv_rx)?;
+
+        let (elders_info, _) = gen_elders_info(good_prefix, ELDER_SIZE);
+        let section_key = bls::SecretKey::random().public_key();
+        let join_task = state.join(elders_info, section_key, None);
+
+        let test_task = async {
+            task::yield_now().await;
+
+            let (bytes, _) = send_rx.try_recv()?;
+            let message = Message::from_bytes(&bytes)?;
+            assert_matches!(message.variant(), Variant::JoinRequest(_));
+
+            // Send `BootstrapResponse::Join` with bad prefix
+            let (elders_info, _) = gen_elders_info(bad_prefix, ELDER_SIZE);
+            let section_key = bls::SecretKey::random().public_key();
+
+            let message = Message::single_src(
+                &bootstrap_node,
+                DstLocation::Direct,
+                Variant::BootstrapResponse(BootstrapResponse::Join {
+                    elders_info,
+                    section_key,
+                }),
+                None,
+                None,
+            )?;
+
+            recv_tx.try_send((message, bootstrap_node.addr))?;
+            task::yield_now().await;
+            assert_matches!(send_rx.try_recv(), Err(TryRecvError::Empty));
+
+            // Send `BootstrapResponse::Join` with good prefix
+            let (elders_info, _) = gen_elders_info(good_prefix, ELDER_SIZE);
+            let section_key = bls::SecretKey::random().public_key();
+
+            let message = Message::single_src(
+                &bootstrap_node,
+                DstLocation::Direct,
+                Variant::BootstrapResponse(BootstrapResponse::Join {
+                    elders_info,
+                    section_key,
+                }),
+                None,
+                None,
+            )?;
+
+            recv_tx.try_send((message, bootstrap_node.addr))?;
+            task::yield_now().await;
+
+            let (bytes, _) = send_rx.try_recv()?;
+            let message = Message::from_bytes(&bytes)?;
+            assert_matches!(message.variant(), Variant::JoinRequest(_));
+
+            Ok(())
+        };
+
+        futures::pin_mut!(join_task);
+        futures::pin_mut!(test_task);
+
+        match future::select(join_task, test_task).await {
+            Either::Left(_) => unreachable!(),
+            Either::Right((output, _)) => output,
+        }
+    }
 }

--- a/src/routing/tests/mod.rs
+++ b/src/routing/tests/mod.rs
@@ -1556,10 +1556,153 @@ async fn handle_elders_update() -> Result<()> {
     Ok(())
 }
 
+// Test that demoted node still sends `Sync` messages to both sub-sections on split.
+#[tokio::test]
+async fn handle_demote_during_split() -> Result<()> {
+    let node = create_node();
+
+    let prefix0 = Prefix::default().pushed(false);
+    let prefix1 = Prefix::default().pushed(true);
+
+    // These peers together with `node` are pre-split elders.
+    // These peers together with `peer_c` are prefix-0 post-split elders.
+    let peers_a: Vec<_> = iter::repeat_with(|| create_peer_in_prefix(&prefix0))
+        .take(ELDER_SIZE - 1)
+        .collect();
+    // These peers are prefix-1 post-split elders.
+    let peers_b: Vec<_> = iter::repeat_with(|| create_peer_in_prefix(&prefix1))
+        .take(ELDER_SIZE)
+        .collect();
+    // This peer is a prefix-0 post-split elder.
+    let peer_c = create_peer_in_prefix(&prefix0);
+
+    // Create the pre-split section
+    let sk_set_v0 = SecretKeySet::random();
+    let elders_info_v0 = EldersInfo::new(
+        iter::once(node.peer()).chain(peers_a.iter().copied()),
+        Prefix::default(),
+    );
+
+    let (mut section, section_key_share) = create_section(&sk_set_v0, &elders_info_v0)?;
+
+    for peer in peers_b.iter().chain(iter::once(&peer_c)) {
+        let member_info = MemberInfo::joined(*peer);
+        let member_info = proven(sk_set_v0.secret_key(), member_info)?;
+        assert!(section.update_member(member_info));
+    }
+
+    let (event_tx, _) = mpsc::unbounded_channel();
+    let state = Approved::new(node, section, Some(section_key_share), event_tx);
+    let stage = Stage::new(state, create_comm()?);
+
+    let sk_set_v1_p0 = SecretKeySet::random();
+    let pk_v1_p0 = sk_set_v1_p0.secret_key().public_key();
+
+    let sk_set_v1_p1 = SecretKeySet::random();
+    let pk_v1_p1 = sk_set_v1_p1.secret_key().public_key();
+
+    // Create consensus on `OurElder` for both sub-sections
+    let create_our_elders_command = |sk, elders_info| -> Result<_> {
+        let proven_elders_info = proven(sk, elders_info)?;
+        let vote = Vote::OurElders(proven_elders_info);
+        let signature = sk_set_v0
+            .secret_key()
+            .sign(&bincode::serialize(&vote.as_signable())?);
+        let proof = Proof {
+            signature,
+            public_key: sk_set_v0.secret_key().public_key(),
+        };
+
+        Ok(Command::HandleConsensus { vote, proof })
+    };
+
+    // Handle consensus on `OurElders` for prefix-0.
+    let elders_info = EldersInfo::new(peers_a.iter().copied().chain(iter::once(peer_c)), prefix0);
+    let command = create_our_elders_command(sk_set_v1_p0.secret_key(), elders_info)?;
+    let commands = stage.handle_command(command).await?;
+    assert_matches!(&commands[..], &[]);
+
+    // Handle consensus on `OurElders` for prefix-1.
+    let elders_info = EldersInfo::new(peers_b.iter().copied(), prefix1);
+    let command = create_our_elders_command(sk_set_v1_p1.secret_key(), elders_info)?;
+    let commands = stage.handle_command(command).await?;
+    assert_matches!(&commands[..], &[]);
+
+    // Create consensus on `TheirKey` for both sub-sections
+    let create_their_key_command = |prefix, key| -> Result<_> {
+        let vote = Vote::TheirKey { prefix, key };
+        let signature = sk_set_v0
+            .secret_key()
+            .sign(&bincode::serialize(&vote.as_signable())?);
+        let proof = Proof {
+            signature,
+            public_key: sk_set_v0.secret_key().public_key(),
+        };
+        Ok(Command::HandleConsensus { vote, proof })
+    };
+
+    // Handle consensus on `TheirKey` for prefix-0
+    let command = create_their_key_command(prefix0, pk_v1_p0)?;
+    let commands = stage.handle_command(command).await?;
+    assert_matches!(&commands[..], &[]);
+
+    // Handle consensus on `TheirKey` for prefix-1
+    let command = create_their_key_command(prefix1, pk_v1_p1)?;
+    let commands = stage.handle_command(command).await?;
+
+    let mut sync_recipients_p0 = HashSet::new();
+    let mut sync_recipients_p1 = HashSet::new();
+
+    for command in commands {
+        let (recipients, message) = match command {
+            Command::SendMessage {
+                recipients,
+                message,
+                ..
+            } => (recipients, message),
+            _ => continue,
+        };
+
+        let message = Message::from_bytes(&message)?;
+        let section = match message.variant() {
+            Variant::Sync { section, .. } => section,
+            _ => continue,
+        };
+
+        match section.chain().last_key() {
+            key if key == &pk_v1_p0 => sync_recipients_p0.extend(recipients),
+            key if key == &pk_v1_p1 => sync_recipients_p1.extend(recipients),
+            key => {
+                panic!(
+                    "unexpected section key: {:?} (expecting {:?} or {:?})",
+                    key, pk_v1_p0, pk_v1_p1
+                );
+            }
+        }
+    }
+
+    let expected_recipients_p0 = peers_a
+        .iter()
+        .map(Peer::addr)
+        .chain(iter::once(peer_c.addr()))
+        .copied()
+        .collect();
+    let expected_recipients_p1 = peers_b.iter().map(Peer::addr).copied().collect();
+
+    assert_eq!(sync_recipients_p0, expected_recipients_p0);
+    assert_eq!(sync_recipients_p1, expected_recipients_p1);
+
+    Ok(())
+}
+
 // TODO: add more tests here
 
 fn create_peer() -> Peer {
     Peer::new(rand::random(), gen_addr(), MIN_AGE)
+}
+
+fn create_peer_in_prefix(prefix: &Prefix) -> Peer {
+    Peer::new(prefix.substituted_in(rand::random()), gen_addr(), MIN_AGE)
 }
 
 fn create_node() -> Node {

--- a/src/routing/tests/mod.rs
+++ b/src/routing/tests/mod.rs
@@ -236,7 +236,7 @@ async fn receive_join_request_from_relocated_node() -> Result<()> {
         relocate_details,
         &relocated_node.name(),
         &relocated_node_old_keypair,
-    )?;
+    );
 
     let join_request = Message::single_src(
         &relocated_node,

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -29,6 +29,7 @@ use crate::{
     ELDER_SIZE, RECOMMENDED_SECTION_SIZE,
 };
 use bls_signature_aggregator::Proof;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, collections::BTreeSet, convert::TryInto, iter, net::SocketAddr};
 use xor_name::{Prefix, XorName};
@@ -134,6 +135,12 @@ impl Section {
             .chain
             .push(new_elders_info.proof.public_key, new_key_proof.signature)
         {
+            error!(
+                "fork attempt detected: new key: {:?}, expected current key: {:?}, actual current chain: {:?}",
+                new_elders_info.proof.public_key,
+                new_key_proof.public_key,
+                self.chain.keys().format("->"),
+            );
             return false;
         }
 

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -137,6 +137,12 @@ impl Section {
         new_elders_info: Proven<EldersInfo>,
         new_key_proof: Proof,
     ) -> bool {
+        if new_elders_info.value.prefix != *self.prefix()
+            && !new_elders_info.value.prefix.is_extension_of(self.prefix())
+        {
+            return false;
+        }
+
         if !new_elders_info.self_verify() {
             return false;
         }

--- a/src/section/section_keys.rs
+++ b/src/section/section_keys.rs
@@ -40,6 +40,10 @@ impl SectionKeysProvider {
         self.current.as_ref().ok_or(Error::MissingSecretKeyShare)
     }
 
+    pub fn has_key_share(&self) -> bool {
+        self.current.is_some()
+    }
+
     pub fn insert_dkg_outcome(&mut self, share: SectionKeyShare) {
         self.pending = Some(share);
     }

--- a/src/section/section_proof_chain.rs
+++ b/src/section/section_proof_chain.rs
@@ -58,7 +58,11 @@ impl SectionProofChain {
 
     /// Pushed a new key into the chain without validating the signature. For testing only.
     #[cfg(test)]
-    pub fn push_without_validation(&mut self, key: bls::PublicKey, signature: bls::Signature) {
+    pub(crate) fn push_without_validation(
+        &mut self,
+        key: bls::PublicKey,
+        signature: bls::Signature,
+    ) {
         self.tail.push(Block { key, signature })
     }
 


### PR DESCRIPTION
Various fixes and tweaks that came up during stress testing. Most notably:

- Fix `Sync` messages not being sent when split and demote happen at the same time
- Add support for multiple concurrent DKG sessions (fixes a situation where a DKG neither completes nor fails)
- Fix `update_state` failing when a node is elder but doesn't yet have its secret key share
- Prevent more than one relocation of the same node at the same time