### PR TITLE
Better error handling

### DIFF
--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -331,12 +331,16 @@ impl Network {
                 RoutingEvent::Relocated { .. } => {
                     if let Some(Node::Joined {
                         node,
+                        name,
                         age,
+                        prefix,
                         is_relocating,
                         ..
                     }) = self.nodes.get_mut(&id)
                     {
+                        *name = node.name().await;
                         *age = node.age().await;
+                        *prefix = node.our_prefix().await;
                         *is_relocating = false;
                         self.stats.relocation_successes += 1;
                     }

--- a/src/consensus/test_utils.rs
+++ b/src/consensus/test_utils.rs
@@ -7,11 +7,13 @@
 // permissions and limitations relating to use of the SAFE Network Software.
 
 use super::{Proof, Proven};
-use crate::error::Result;
 use serde::Serialize;
 
 // Create proof for the given payload using the given secret key.
-pub fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<Proof> {
+pub fn prove<T: Serialize>(
+    secret_key: &bls::SecretKey,
+    payload: &T,
+) -> Result<Proof, bincode::Error> {
     let bytes = bincode::serialize(payload)?;
     Ok(Proof {
         public_key: secret_key.public_key(),
@@ -20,7 +22,10 @@ pub fn prove<T: Serialize>(secret_key: &bls::SecretKey, payload: &T) -> Result<P
 }
 
 // Wrap the given payload in `Proven`
-pub fn proven<T: Serialize>(secret_key: &bls::SecretKey, payload: T) -> Result<Proven<T>> {
+pub fn proven<T: Serialize>(
+    secret_key: &bls::SecretKey,
+    payload: T,
+) -> Result<Proven<T>, bincode::Error> {
     let proof = prove(secret_key, &payload)?;
     Ok(Proven::new(payload, proof))
 }

--- a/src/consensus/vote.rs
+++ b/src/consensus/vote.rs
@@ -74,7 +74,7 @@ impl Vote {
         public_key_set: bls::PublicKeySet,
         index: usize,
         secret_key_share: &bls::SecretKeyShare,
-    ) -> Result<ProofShare> {
+    ) -> Result<ProofShare, bincode::Error> {
         Ok(ProofShare::new(
             public_key_set,
             index,

--- a/src/delivery_group.rs
+++ b/src/delivery_group.rs
@@ -83,7 +83,7 @@ pub(crate) fn delivery_targets(
 
             candidates(target_name, our_name, section, network)?
         }
-        DstLocation::Direct => return Err(Error::CannotRoute),
+        DstLocation::Direct => return Err(Error::InvalidDstLocation),
     };
 
     Ok((best_section, dg_size))

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,7 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 // TODO: consider removing those variants that cannot occur when calling the public API.
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum Error {
     #[error("network layer error: {}", .0)]
     Network(#[from] qp2p::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,37 +6,43 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
+use crate::{messages, section};
 use thiserror::Error;
 
 /// The type returned by the sn_routing message handling methods.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-/// Internal error.
+/// Routing error.
+// TODO: consider removing those variants that cannot occur when calling the public API.
 #[derive(Debug, Error)]
 #[allow(missing_docs)]
 pub enum Error {
-    #[error("Failed signature check.")]
-    FailedSignature,
-    #[error("Cannot route.")]
-    CannotRoute,
-    #[error("Network layer error: {}", .0)]
+    #[error("network layer error: {}", .0)]
     Network(#[from] qp2p::Error),
-    #[error("The node is not in a state to handle the action.")]
-    InvalidState,
-    #[error("Bincode error: {}", .0)]
-    Bincode(#[from] bincode::Error),
-    #[error("Invalid source location.")]
+    #[error("node bootstrap was interrupted")]
+    BootstrapInterrupted,
+    #[error("failed to create genesis section: {}", .0)]
+    CreateGenesisSection(#[source] section::CreateError),
+    #[error("failed to merge sections: {}", .0)]
+    MergeSection(#[from] section::MergeError),
+    #[error("failed to create message: {}", .0)]
+    CreateMessage(#[from] messages::CreateError),
+    #[error("received invalid message: {}", .0)]
+    InvalidMessage(#[from] messages::IntegrityError),
+    #[error("failed to send a message")]
+    SendMessage,
+    #[error("failed to create vote proof share: {}", .0)]
+    CreateVoteProofShare(#[source] bincode::Error),
+    #[error("received invalid vote proof share")]
+    InvalidVoteProofShare,
+    #[error("failed to create resource challenge: {}", .0)]
+    CreateResourceChallenge(#[source] bincode::Error),
+    #[error("invalid message source location")]
     InvalidSrcLocation,
-    #[error("Invalid destination location.")]
+    #[error("invalid message destination location")]
     InvalidDstLocation,
-    #[error("Content of a received message is inconsistent.")]
-    InvalidMessage,
-    #[error("A signature share is invalid.")]
-    InvalidSignatureShare,
-    #[error("The secret key share is missing.")]
+    #[error("the secret key share is missing")]
     MissingSecretKeyShare,
-    #[error("Failed to send a message.")]
-    FailedSend,
-    #[error("Invalid vote.")]
-    InvalidVote,
+    #[error("cannot route")]
+    CannotRoute,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,12 @@ pub use self::{
     error::{Error, Result},
     event::{Event, SendStream},
     location::{DstLocation, SrcLocation},
+    messages::{CreateError as MessageCreateError, IntegrityError as MessageIntegrityError},
     routing::{Config, EventStream, Routing},
-    section::{SectionProofChain, MIN_AGE},
+    section::{
+        CreateError as SectionCreateError, MergeError as SectionMergeError, SectionProofChain,
+        MIN_AGE,
+    },
 };
 pub use qp2p::Config as TransportConfig;
 

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -316,34 +316,19 @@ pub enum MessageStatus {
     Unknown,
 }
 
-#[derive(Debug, Error)]
-pub enum ParseError {
-    #[error("failed to deserialize message: {}", .0)]
-    Deserialize(#[from] bincode::Error),
-    #[error("signature check failed")]
-    FailedSignature,
-}
-
 /// Error when creating a message.
 #[derive(Debug, Error)]
+#[non_exhaustive]
+#[allow(missing_docs)]
 pub enum CreateError {
     #[error("failed to serialize message: {}", .0)]
     Serialize(#[from] bincode::Error),
 }
 
-/// Error returned from `Message::extend_proof_chain`.
-#[derive(Debug, Error)]
-pub enum ExtendProofChainError {
-    #[error("message has no proof chain")]
-    NoProofChain,
-    #[error("failed to extend proof chain: {}", .0)]
-    Extend(#[from] ExtendError),
-    #[error("failed to re-create message: {}", .0)]
-    Create(#[from] CreateError),
-}
-
 /// Error when checking message integrity.
 #[derive(Debug, Error)]
+#[non_exhaustive]
+#[allow(missing_docs)]
 pub enum IntegrityError {
     #[error("proof chain is missing")]
     ProofChainMissing,
@@ -355,6 +340,25 @@ pub enum IntegrityError {
     Untrusted,
     #[error("wrong message variant")]
     WrongVariant,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ParseError {
+    #[error("failed to deserialize message: {}", .0)]
+    Deserialize(#[from] bincode::Error),
+    #[error("signature check failed")]
+    FailedSignature,
+}
+
+/// Error returned from `Message::extend_proof_chain`.
+#[derive(Debug, Error)]
+pub(crate) enum ExtendProofChainError {
+    #[error("message has no proof chain")]
+    NoProofChain,
+    #[error("failed to extend proof chain: {}", .0)]
+    Extend(#[from] ExtendError),
+    #[error("failed to re-create message: {}", .0)]
+    Create(#[from] CreateError),
 }
 
 impl Into<Result<(), IntegrityError>> for TrustStatus {

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -325,7 +325,6 @@ pub enum ParseError {
 }
 
 /// Error when creating a message.
-#[allow(missing_docs)]
 #[derive(Debug, Error)]
 pub enum CreateError {
     #[error("failed to serialize message: {}", .0)]
@@ -344,7 +343,6 @@ pub enum ExtendProofChainError {
 }
 
 /// Error when checking message integrity.
-#[allow(missing_docs)]
 #[derive(Debug, Error)]
 pub enum IntegrityError {
     #[error("proof chain is missing")]

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -302,7 +302,11 @@ impl Approved {
 
     // Send `vote` to `recipients`.
     fn send_vote(&self, recipients: &[Peer], vote: Vote) -> Result<Vec<Command>> {
-        let key_share = self.section_keys_provider.key_share()?;
+        let key_share = self.section_keys_provider.key_share().map_err(|error| {
+            error!("Failed to vote for {:?} - missing secret key share", vote);
+            error
+        })?;
+
         self.send_vote_with(recipients, vote, key_share)
     }
 
@@ -1902,7 +1906,14 @@ impl Approved {
 
         let last_key = self
             .section_keys_provider
-            .key_share()?
+            .key_share()
+            .map_err(|error| {
+                error!(
+                    "Failed to create proof chain for {:?} - missing secret key share",
+                    dst
+                );
+                error
+            })?
             .public_key_set
             .public_key();
         let last_index = self

--- a/src/routing/bootstrap.rs
+++ b/src/routing/bootstrap.rs
@@ -415,7 +415,12 @@ impl<'a> State<'a> {
                     }
 
                     // Transition from Joining to Approved
-                    let section_chain = message.proof_chain()?.clone();
+                    let section_chain = if let Ok(chain) = message.proof_chain() {
+                        chain.clone()
+                    } else {
+                        trace!("Ignore NodeApproval without proof chain");
+                        continue;
+                    };
 
                     info!(
                         "{} This node has been approved to join the network at {:?}!",

--- a/src/routing/bootstrap.rs
+++ b/src/routing/bootstrap.rs
@@ -44,7 +44,7 @@ pub(crate) async fn initial(
     let (send_tx, send_rx) = mpsc::channel(1);
     let recv_rx = MessageReceiver::Raw(incoming_conns);
 
-    let state = State::new(node, send_tx, recv_rx)?;
+    let state = State::new(node, send_tx, recv_rx);
 
     future::join(
         state.run(vec![bootstrap_addr], None),
@@ -69,7 +69,7 @@ pub(crate) async fn relocate(
     let (send_tx, send_rx) = mpsc::channel(1);
     let recv_rx = MessageReceiver::Deserialized(recv_rx);
 
-    let state = State::new(node, send_tx, recv_rx)?;
+    let state = State::new(node, send_tx, recv_rx);
 
     future::join(
         state.run(bootstrap_addrs, Some(relocate_details)),
@@ -94,13 +94,13 @@ impl<'a> State<'a> {
         node: Node,
         send_tx: mpsc::Sender<(Bytes, Vec<SocketAddr>)>,
         recv_rx: MessageReceiver<'a>,
-    ) -> Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             send_tx,
             recv_rx,
             node,
             backlog: VecDeque::with_capacity(BACKLOG_CAPACITY),
-        })
+        }
     }
 
     async fn run(
@@ -555,7 +555,7 @@ mod tests {
 
         let node = Node::new(crypto::gen_keypair(), gen_addr());
         let peer = node.peer();
-        let state = State::new(node, send_tx, recv_rx)?;
+        let state = State::new(node, send_tx, recv_rx);
 
         // Create the bootstrap task, but don't run it yet.
         let bootstrap = async move {
@@ -642,7 +642,7 @@ mod tests {
         let bootstrap_node = Node::new(crypto::gen_keypair(), gen_addr());
 
         let node = Node::new(crypto::gen_keypair(), gen_addr());
-        let mut state = State::new(node, send_tx, recv_rx)?;
+        let mut state = State::new(node, send_tx, recv_rx);
 
         let bootstrap_task = state.bootstrap(vec![bootstrap_node.addr], None);
         let test_task = async {
@@ -699,7 +699,7 @@ mod tests {
         let bootstrap_node = Node::new(crypto::gen_keypair(), gen_addr());
 
         let node = Node::new(crypto::gen_keypair(), gen_addr());
-        let mut state = State::new(node, send_tx, recv_rx)?;
+        let mut state = State::new(node, send_tx, recv_rx);
 
         let bootstrap_task = state.bootstrap(vec![bootstrap_node.addr], None);
         let test_task = async {
@@ -769,7 +769,7 @@ mod tests {
             }
         };
 
-        let mut state = State::new(node, send_tx, recv_rx)?;
+        let mut state = State::new(node, send_tx, recv_rx);
 
         let bootstrap_task = state.bootstrap(vec![bootstrap_node.addr], None);
 
@@ -842,7 +842,7 @@ mod tests {
             }
         };
 
-        let state = State::new(node, send_tx, recv_rx)?;
+        let state = State::new(node, send_tx, recv_rx);
 
         let (elders_info, _) = gen_elders_info(good_prefix, ELDER_SIZE);
         let section_key = bls::SecretKey::random().public_key();

--- a/src/routing/comm.rs
+++ b/src/routing/comm.rs
@@ -232,7 +232,7 @@ pub struct SendError;
 
 impl From<SendError> for Error {
     fn from(_: SendError) -> Self {
-        Error::FailedSend
+        Error::SendMessage
     }
 }
 

--- a/src/routing/tests/mod.rs
+++ b/src/routing/tests/mod.rs
@@ -18,7 +18,6 @@ use crate::{
     majority,
     messages::{
         BootstrapResponse, JoinRequest, Message, PlainMessage, ResourceProofResponse, Variant,
-        VerifyStatus,
     },
     network::Network,
     node::Node,
@@ -681,7 +680,8 @@ async fn handle_consensus_on_offline_of_elder() -> Result<()> {
         .members()
         .get(remove_peer.name())
         .expect("member not found")
-        .leave()?;
+        .leave()
+        .expect("member not joined");
 
     // Create our node
     let (event_tx, mut event_rx) = mpsc::unbounded_channel();
@@ -1292,7 +1292,7 @@ async fn receive_message_with_invalid_proof_chain() -> Result<()> {
         })
         .await;
 
-    assert_matches!(result, Err(Error::InvalidMessage));
+    assert_matches!(result, Err(Error::InvalidMessage(_)));
 
     Ok(())
 }
@@ -1526,7 +1526,7 @@ async fn handle_elders_update() -> Result<()> {
         // The message is trusted even by peers who don't yet know the new section key.
         assert_matches!(
             message.verify(iter::once((&Prefix::default(), &pk0))),
-            Ok(VerifyStatus::Full)
+            Ok(())
         );
 
         // Merging the section contained in the message with the original section succeeds.

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -45,7 +45,6 @@ impl Section {
         elders_info: Proven<EldersInfo>,
     ) -> Result<Self, CreateError> {
         if !chain.has_key(&elders_info.proof.public_key) {
-            // TODO: consider more specific error here.
             return Err(CreateError::UntrustedEldersInfoSigningKey);
         }
 
@@ -347,7 +346,6 @@ impl Section {
 }
 
 /// Error when creating section.
-#[allow(missing_docs)]
 #[derive(Debug, Error)]
 pub enum CreateError {
     #[error("elders info signing key is not in the chain")]

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -347,6 +347,8 @@ impl Section {
 
 /// Error when creating section.
 #[derive(Debug, Error)]
+#[non_exhaustive]
+#[allow(missing_docs)]
 pub enum CreateError {
     #[error("elders info signing key is not in the chain")]
     UntrustedEldersInfoSigningKey,
@@ -360,6 +362,8 @@ pub enum CreateError {
 
 /// Error when merging sections.
 #[derive(Debug, Error)]
+#[non_exhaustive]
+#[allow(missing_docs)]
 pub enum MergeError {
     #[error("the chain of the other section is invalid")]
     InvalidOtherChain,

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -216,7 +216,7 @@ impl Section {
         &self,
         their_knowledge: Option<u64>,
     ) -> SectionProofChain {
-        let first_index = self.elders_info_signing_key_index();
+        let first_index = self.chain.last_key_index();
         let first_index = their_knowledge.unwrap_or(first_index).min(first_index);
         self.chain.slice(first_index..)
     }
@@ -286,15 +286,6 @@ impl Section {
             .joined()
             .find(|info| info.peer.addr() == addr)
             .map(|info| &info.peer)
-    }
-
-    fn elders_info_signing_key_index(&self) -> u64 {
-        // NOTE: we assume that the key the current `EldersInfo` is signed with is always
-        // present in our section proof chain. This is guaranteed, because we update both the
-        // elders info and the section chain together in a single operation.
-        self.chain
-            .index_of(&self.elders_info.proof.public_key)
-            .unwrap_or_else(|| unreachable!("EldersInfo signed with unknown key"))
     }
 
     // Tries to split our section.


### PR DESCRIPTION
Improve error handling in routing:

- Remove redundant and ambiguous variants from `Error`
- Add more specific variants and make them contain more information
- Use multiple small and specialized error types instead of one big error type everywhere. There is still only one public error type though.

Additionally and unrelated to error handling:
- fix a bug in the stress test
- log more info in some cases
- minor refactoring