### PR TITLE
chore: use deny(warnings) instead of forbid(warnings)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,7 @@
     arithmetic_overflow,
     mutable_transmutes,
     no_mangle_const_items,
-    unknown_crate_types,
-    warnings
+    unknown_crate_types
 )]
 #![deny(
     bad_style,
@@ -52,7 +51,8 @@
     while_true,
     clippy::unicode_not_nfc,
     clippy::wrong_pub_self_convention,
-    deprecated
+    deprecated,
+    warnings
 )]
 #![warn(
     trivial_casts,

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -306,7 +306,7 @@ where
         let child1 = other.pushed(true);
 
         check(our, &child0, known) && check(our, &child1, known)
-    };
+    }
 
     check(our, other, &known)
 }


### PR DESCRIPTION
`deny` can be overriden with `allow`, unlike `forbid`. This allows us to `allow` some warnings on a case-by-case basis which is especially useful in macros. Without this, some macros from other crates caused compilation errors on nightly, however it's possible it would eventually affect stable as well.