### PR TITLE
refactor(event): move promoted/demoted to elderschanged

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -226,14 +226,8 @@ fn run_node(index: usize, mut node: Routing, mut event_stream: EventStream) -> J
 // Handles the event emitted by the node.
 async fn handle_event(index: usize, node: &mut Routing, event: Event) -> bool {
     match event {
-        Event::PromotedToElder => {
-            info!("Node #{} promoted to Elder", index);
-        }
         Event::PromotedToAdult => {
             info!("Node #{} promoted to Adult", index);
-        }
-        Event::Demoted => {
-            info!("Node #{} demoted", index);
         }
         Event::MemberJoined {
             name,
@@ -253,10 +247,11 @@ async fn handle_event(index: usize, node: &mut Routing, event: Event) -> bool {
             prefix,
             key,
             elders,
+            self_status_change,
         } => {
             info!(
-                "Node #{} elders changed - prefix: {:b}, key: {:?}, elders: {:?}",
-                index, prefix, key, elders
+                "Node #{} elders changed - prefix: {:b}, key: {:?}, elders: {:?}. Node elder status change: {:?}",
+                index, prefix, key, elders, self_status_change
             );
         }
         Event::MessageReceived { content, src, dst } => info!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ extern crate tracing;
 // ############################################################################
 pub use self::{
     error::{Error, Result},
-    event::{Event, SendStream},
+    event::{Event, NodeElderChange, SendStream},
     location::{DstLocation, SrcLocation},
     routing::{Config, EventStream, Routing},
     section::{SectionProofChain, MIN_AGE},

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -10,7 +10,7 @@ mod utils;
 
 use self::utils::*;
 use anyhow::Result;
-use sn_routing::Event;
+use sn_routing::{Event, NodeElderChange};
 
 #[tokio::test]
 async fn test_node_drop() -> Result<()> {
@@ -19,7 +19,7 @@ async fn test_node_drop() -> Result<()> {
     let mut nodes = create_connected_nodes(3).await?;
 
     for (_, events) in &mut nodes[1..] {
-        assert_event!(events, Event::PromotedToElder);
+        assert_event!(events, Event::EldersChanged { self_status_change: NodeElderChange::Promoted, .. });
     }
 
     // Wait for the DKG(s) to complete, to make sure there are no more messages being exchanged

--- a/tests/messages.rs
+++ b/tests/messages.rs
@@ -11,7 +11,7 @@ mod utils;
 use anyhow::{format_err, Result};
 use bytes::Bytes;
 use qp2p::QuicP2p;
-use sn_routing::{Config, DstLocation, Error, Event, SrcLocation};
+use sn_routing::{Config, DstLocation, Error, Event, NodeElderChange, SrcLocation};
 use std::net::{IpAddr, Ipv4Addr};
 use utils::*;
 
@@ -95,7 +95,7 @@ async fn test_messages_between_nodes() -> Result<()> {
     // start a second node which sends a message to the first node
     let (node2, mut event_stream) = create_node(config_with_contact(node1_contact)).await?;
 
-    assert_event!(event_stream, Event::PromotedToElder);
+    assert_event!(event_stream, Event::EldersChanged { self_status_change: NodeElderChange::Promoted, .. });
 
     let node2_name = node2.name().await;
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -14,7 +14,7 @@ use anyhow::{bail, format_err, Error, Result};
 use ed25519_dalek::Keypair;
 use futures::future;
 use itertools::Itertools;
-use sn_routing::{Config, Event, EventStream, Routing, TransportConfig, MIN_AGE};
+use sn_routing::{Config, Event, EventStream, NodeElderChange, Routing, TransportConfig, MIN_AGE};
 use std::{
     collections::{BTreeSet, HashSet},
     iter,
@@ -96,7 +96,7 @@ pub async fn create_connected_nodes(count: usize) -> Result<Vec<(Routing, EventS
         ..Default::default()
     })
     .await?;
-    assert_next_event!(event_stream, Event::PromotedToElder);
+    assert_next_event!(event_stream, Event::EldersChanged { self_status_change: NodeElderChange::Promoted, .. });
 
     let bootstrap_contact = node.our_connection_info().await?;
 


### PR DESCRIPTION
- Removes `PromotedToAdult` and `Demoted` variants of `Event` enum.
- Adds `NodeElderChange` enum.
- Adds the flag `self_status_change` to `EldersChanged` variant, indicating whether the node got promoted, demoted or did not change.
