### PR TITLE
chore(ci): update semgrep ci check to use config from semgrep.dev

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,6 +11,5 @@ jobs:
       with:
         publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
         publishDeployment: 346
-        config: p/r2c
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Shouldn't need to specify config in semgrep.yml - replaced API key at same time as this change as perhaps this is why it was failing before.