### PR TITLE
chore(data-types): upgrading data-types to v0.16.0 and sn_messaging to v8.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ rand_chacha = "~0.2.2"
 thiserror = "1.0.23"
 xor_name = "1.1.0"
 resource_proof = "0.8.0"
-sn_messaging = "~7.0.0"
-sn_data_types = "~0.15.0"
+sn_messaging = "~8.0.0"
+sn_data_types = "~0.16.0"
 
   [dependencies.bls]
   package = "threshold_crypto"


### PR DESCRIPTION
BREAKING CHANGE: new Sequence data-type doesn't allow Policy mutations.