### PR TITLE
feat!: remove unused events and event properties

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -223,18 +223,14 @@ fn run_node(index: usize, mut node: Routing, mut event_stream: EventStream) -> J
 // Handles the event emitted by the node.
 async fn handle_event(index: usize, node: &mut Routing, event: Event) -> bool {
     match event {
-        Event::PromotedToAdult => {
-            info!("Node #{} promoted to Adult", index);
-        }
         Event::MemberJoined {
             name,
             previous_name,
             age,
-            startup_relocation,
         } => {
             info!(
-                "Node #{} member joined - name: {}, previous_name: {:?}, age: {}, startup_relocation: {}",
-                index, name, previous_name, age, startup_relocation
+                "Node #{} member joined - name: {}, previous_name: {:?}, age: {}",
+                index, name, previous_name, age
             );
         }
         Event::MemberLeft { name, age } => {

--- a/src/event.rs
+++ b/src/event.rs
@@ -48,8 +48,6 @@ pub enum Event {
         /// The destination location that receives the message.
         dst: DstLocation,
     },
-    /// The node has been promoted to adult
-    PromotedToAdult,
     /// A new peer joined our section.
     MemberJoined {
         /// Name of the node
@@ -58,8 +56,6 @@ pub enum Event {
         previous_name: Option<XorName>,
         /// Age of the node
         age: u8,
-        /// Indication that is has been relocated during startup.
-        startup_relocation: bool,
     },
     /// A node left our section.
     MemberLeft {
@@ -119,18 +115,15 @@ impl Debug for Event {
                 src,
                 dst
             ),
-            Self::PromotedToAdult => write!(formatter, "PromotedToAdult"),
             Self::MemberJoined {
                 name,
                 previous_name,
                 age,
-                startup_relocation,
             } => formatter
                 .debug_struct("MemberJoined")
                 .field("name", name)
                 .field("previous_name", previous_name)
                 .field("age", age)
-                .field("startup_relocation", startup_relocation)
                 .finish(),
             Self::MemberLeft { name, age } => formatter
                 .debug_struct("MemberLeft")

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -34,7 +34,7 @@ use crate::{
         EldersInfo, MemberInfo, PeerState, Section, SectionChain, SectionKeyShare,
         SectionKeysProvider, MIN_AGE,
     },
-    ELDER_SIZE, RECOMMENDED_SECTION_SIZE,
+    ELDER_SIZE,
 };
 use bls_dkg::key_gen::message::Message as DkgMessage;
 use bls_signature_aggregator::{Error as AggregatorError, SignatureAggregator};
@@ -1476,13 +1476,6 @@ impl Approved {
         self.send_relocate(peer, details)
     }
 
-    // Are we in the startup phase? Startup phase is when the network consists of only one section
-    // and it has no more than `recommended_section_size` members.
-    fn is_in_startup_phase(&self) -> bool {
-        self.section.prefix().is_empty()
-            && self.section.members().joined().count() <= RECOMMENDED_SECTION_SIZE
-    }
-
     fn handle_online_event(
         &mut self,
         new_info: MemberInfo,
@@ -1491,8 +1484,6 @@ impl Approved {
         proof: Proof,
     ) -> Result<Vec<Command>> {
         let mut commands = vec![];
-
-        let is_startup_phase = self.is_in_startup_phase();
 
         if let Some(old_info) = self.section.members().get_proven(new_info.peer.name()) {
             // This node is rejoin with same name.
@@ -1535,7 +1526,6 @@ impl Approved {
             name: *new_info.value.peer.name(),
             previous_name,
             age: new_info.value.peer.age(),
-            startup_relocation: is_startup_phase,
         });
 
         commands


### PR DESCRIPTION
BREAKING CHANGE: remove `Event::PromotedToAdult` and the `startup_relocation` field of `Event::MemberJoined`, both parts of public API.