### PR TITLE
feat: keep the genesis key and use it for fallback proofs

### DIFF
--- a/src/delivery_group.rs
+++ b/src/delivery_group.rs
@@ -406,7 +406,7 @@ mod tests {
         let elders0: Vec<_> = elders_info0.peers().copied().collect();
         let elders_info0 = proven(&sk, elders_info0)?;
 
-        let mut section = Section::new(chain, elders_info0)?;
+        let mut section = Section::new(pk, chain, elders_info0)?;
 
         for peer in elders0 {
             let member_info = MemberInfo::joined(peer);
@@ -434,7 +434,7 @@ mod tests {
 
         let (elders_info, _) = gen_elders_info(prefix0, ELDER_SIZE);
         let elders_info = proven(&sk, elders_info)?;
-        let section = Section::new(chain, elders_info)?;
+        let section = Section::new(pk, chain, elders_info)?;
 
         let network = Network::new();
         let our_name = section.prefix().substituted_in(rand::random());

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -43,6 +43,7 @@ pub(crate) enum Variant {
     /// Message sent to newly joined node containing the necessary info to become a member of our
     /// section.
     NodeApproval {
+        genesis_key: bls::PublicKey,
         elders_info: Proven<EldersInfo>,
         member_info: Proven<MemberInfo>,
     },
@@ -127,6 +128,7 @@ impl Variant {
             Self::NodeApproval {
                 elders_info,
                 member_info,
+                ..
             } => {
                 let proof_chain = proof_chain.ok_or(Error::InvalidMessage)?;
 
@@ -171,10 +173,12 @@ impl Debug for Variant {
                 .finish(),
             Self::UserMessage(payload) => write!(f, "UserMessage({:10})", HexFmt(payload)),
             Self::NodeApproval {
+                genesis_key,
                 elders_info,
                 member_info,
             } => f
                 .debug_struct("NodeApproval")
+                .field("genesis_key", genesis_key)
                 .field("elders_info", elders_info)
                 .field("member_info", member_info)
                 .finish(),

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -345,7 +345,7 @@ mod tests {
         );
         let elders_info = proven(&sk, elders_info)?;
 
-        let mut section = Section::new(SectionChain::new(pk), elders_info)?;
+        let mut section = Section::new(pk, SectionChain::new(pk), elders_info)?;
 
         for peer in &peers {
             let info = MemberInfo::joined(*peer);

--- a/src/routing/approved.rs
+++ b/src/routing/approved.rs
@@ -824,7 +824,8 @@ impl Approved {
             .section
             .chain()
             .keys()
-            .chain(self.network.keys().map(|(_, key)| key));
+            .chain(self.network.keys().map(|(_, key)| key))
+            .chain(iter::once(self.section.genesis_key()));
 
         match msg.verify(known_keys) {
             Ok(VerifyStatus::Full) => Ok(true),
@@ -1836,6 +1837,7 @@ impl Approved {
         )?;
 
         let variant = Variant::NodeApproval {
+            genesis_key: *self.section.genesis_key(),
             elders_info: self.section.proven_elders_info().clone(),
             member_info,
         };

--- a/src/routing/lazy_messaging.rs
+++ b/src/routing/lazy_messaging.rs
@@ -319,7 +319,8 @@ mod tests {
             let node = nodes.remove(0);
 
             let elders_info0 = proven(&our_sk, elders_info0)?;
-            let section = Section::new(chain, elders_info0).context("failed to create section")?;
+            let section = Section::new(*chain.root_key(), chain, elders_info0)
+                .context("failed to create section")?;
 
             let (elders_info1, _) = gen_elders_info(prefix1, ELDER_SIZE);
             let elders_info1 = proven(&our_sk, elders_info1)?;

--- a/src/routing/split_barrier.rs
+++ b/src/routing/split_barrier.rs
@@ -234,7 +234,7 @@ mod tests {
         let elders_info = EldersInfo::new(elders, Prefix::default());
         let elders_info = proven(&sk, elders_info)?;
 
-        let mut section = Section::new(chain, elders_info)?;
+        let mut section = Section::new(pk, chain, elders_info)?;
 
         for peer in members0.iter().chain(&members1).copied() {
             let info = MemberInfo::joined(peer);


### PR DESCRIPTION
Every node now always has the genesis key. This means we can now always provide valid proof chain for anyone because if all else fails we can always fall back to sending the full section chain.

Closes #2372. 