### PR TITLE
fix!: adults not able to send non-aggregated messages

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -79,8 +79,8 @@ pub enum Event {
         src: SrcLocation,
         /// The destination location that receives the message.
         dst: DstLocation,
-        /// The proof chain for the message.
-        proof_chain: SectionChain,
+        /// The proof chain for the message, if any.
+        proof_chain: Option<SectionChain>,
     },
     /// A new peer joined our section.
     MemberJoined {


### PR DESCRIPTION
BREAKING CHANGE: The `proof_chain` field of `Event::MessageReceived` is now `Option`.