### PR TITLE
Change EldersInto to SectionAuthorityProvider

### DIFF
--- a/src/agreement/proposal.rs
+++ b/src/agreement/proposal.rs
@@ -10,7 +10,7 @@ use super::{Proof, ProofShare, Proven, SignatureAggregator};
 use crate::{
     error::Result,
     messages::PlainMessage,
-    section::{EldersInfo, MemberInfo, SectionChain},
+    section::{MemberInfo, SectionAuthorityProvider, SectionChain},
 };
 use serde::{Deserialize, Serialize, Serializer};
 use thiserror::Error;
@@ -37,19 +37,19 @@ pub(crate) enum Proposal {
     //    This proposal is then signed by the newly generated section key.
     // 2. To update information about other section in the network. In this case the proposal is
     //    signed by an existing key from the chain.
-    SectionInfo(EldersInfo),
+    SectionInfo(SectionAuthorityProvider),
 
     // Proposal to change the elders (and possibly the prefix) of our section.
-    // NOTE: the `EldersInfo` is already signed with the new key. This proposal is only to signs the
+    // NOTE: the `SectionAuthorityProvider` is already signed with the new key. This proposal is only to signs the
     // new key with the current key. That way, when it aggregates, we obtain all the following
     // pieces of information at the same time:
-    //   1. the new elders info
+    //   1. the new section authority provider
     //   2. the new key
-    //   3. the signature of the new elders info using the new key
+    //   3. the signature of the new section authority provider using the new key
     //   4. the signature of the new key using the current key
-    // Which we can use to update the section elders info and the section chain at the same time as
-    // a single atomic operation without needing to cache anything.
-    OurElders(Proven<EldersInfo>),
+    // Which we can use to update the section section authority provider and the section chain at
+    // the same time as a single atomic operation without needing to cache anything.
+    OurElders(Proven<SectionAuthorityProvider>),
 
     // Proposal to update other section key.
     TheirKey {
@@ -152,15 +152,16 @@ mod tests {
     #[test]
     fn serialize_for_signing() -> Result<()> {
         // Proposal::SectionInfo
-        let (elders_info, _) = section::test_utils::gen_elders_info(Default::default(), 4);
-        let proposal = Proposal::SectionInfo(elders_info.clone());
-        verify_serialize_for_signing(&proposal, &elders_info)?;
+        let (section_auth, _) =
+            section::test_utils::gen_section_authority_provider(Default::default(), 4);
+        let proposal = Proposal::SectionInfo(section_auth.clone());
+        verify_serialize_for_signing(&proposal, &section_auth)?;
 
         // Proposal::OurElders
         let new_sk = bls::SecretKey::random();
         let new_pk = new_sk.public_key();
-        let proven_elders_info = agreement::test_utils::proven(&new_sk, elders_info)?;
-        let proposal = Proposal::OurElders(proven_elders_info);
+        let proven_section_auth = agreement::test_utils::proven(&new_sk, section_auth)?;
+        let proposal = Proposal::OurElders(proven_section_auth);
         verify_serialize_for_signing(&proposal, &new_pk)?;
 
         // Proposal::TheirKey

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -511,8 +511,9 @@ mod tests {
         let pk1_sig = sk0.sign(&bincode::serialize(&pk1)?);
         let _ = full_proof_chain.insert(&pk0, pk1, pk1_sig);
 
-        let (elders_info, _) = section::test_utils::gen_elders_info(Default::default(), 3);
-        let elders_info = agreement::test_utils::proven(&sk1, elders_info)?;
+        let (section_auth, _) =
+            section::test_utils::gen_section_authority_provider(Default::default(), 3);
+        let section_auth = agreement::test_utils::proven(&sk1, section_auth)?;
 
         let peer = Peer::new(rand::random(), gen_addr());
         let member_info = MemberInfo::joined(peer);
@@ -520,7 +521,7 @@ mod tests {
 
         let variant = Variant::NodeApproval {
             genesis_key: pk0,
-            elders_info,
+            section_auth,
             member_info,
         };
         let message = Message::single_src(

--- a/src/messages/variant.rs
+++ b/src/messages/variant.rs
@@ -13,7 +13,7 @@ use crate::{
     error::{Error, Result},
     network::Network,
     relocation::{RelocateDetails, RelocatePayload, RelocatePromise},
-    section::{EldersInfo, MemberInfo, Section, SectionChain},
+    section::{MemberInfo, Section, SectionAuthorityProvider, SectionChain},
 };
 use bls_dkg::key_gen::message::Message as DkgMessage;
 use bytes::Bytes;
@@ -31,8 +31,8 @@ use std::{
 pub(crate) enum Variant {
     /// Inform other sections about our section or vice-versa.
     OtherSection {
-        /// `EldersInfo` of the sender's section, with the proof chain.
-        elders_info: Proven<EldersInfo>,
+        /// `SectionAuthorityProvider` of the sender's section, with the proof chain.
+        section_auth: Proven<SectionAuthorityProvider>,
         /// Nonce that is derived from the incoming message that triggered sending this
         /// message. It's purpose is to make sure that `OtherSection`s that are identical
         /// but triggered by different messages are not filtered out.
@@ -44,7 +44,7 @@ pub(crate) enum Variant {
     /// section.
     NodeApproval {
         genesis_key: bls::PublicKey,
-        elders_info: Proven<EldersInfo>,
+        section_auth: Proven<SectionAuthorityProvider>,
         member_info: Proven<MemberInfo>,
     },
     /// Message sent to all members to update them about the state of our section.
@@ -65,7 +65,7 @@ pub(crate) enum Variant {
     JoinRequest(Box<JoinRequest>),
     /// Response to outdated JoinRequest
     JoinRetry {
-        elders_info: EldersInfo,
+        section_auth: SectionAuthorityProvider,
         section_key: bls::PublicKey,
     },
     /// Sent from a node that can't establish the trust of the contained message to its original
@@ -84,7 +84,7 @@ pub(crate) enum Variant {
         /// The identifier of the DKG session to start.
         dkg_key: DkgKey,
         /// The DKG particpants.
-        elders_info: EldersInfo,
+        section_auth: SectionAuthorityProvider,
     },
     /// Message exchanged for DKG process.
     DkgMessage {
@@ -126,13 +126,13 @@ impl Variant {
     {
         let proof_chain = match self {
             Self::NodeApproval {
-                elders_info,
+                section_auth,
                 member_info,
                 ..
             } => {
                 let proof_chain = proof_chain.ok_or(Error::InvalidMessage)?;
 
-                if !elders_info.verify(proof_chain) {
+                if !section_auth.verify(proof_chain) {
                     return Err(Error::InvalidMessage);
                 }
 
@@ -143,10 +143,10 @@ impl Variant {
                 proof_chain
             }
             Self::Sync { section, .. } => section.chain(),
-            Self::OtherSection { elders_info, .. } => {
+            Self::OtherSection { section_auth, .. } => {
                 let proof_chain = proof_chain.ok_or(Error::InvalidMessage)?;
 
-                if !elders_info.verify(proof_chain) {
+                if !section_auth.verify(proof_chain) {
                     return Err(Error::InvalidMessage);
                 }
 
@@ -166,25 +166,28 @@ impl Variant {
 impl Debug for Variant {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Self::OtherSection { elders_info, nonce } => f
+            Self::OtherSection {
+                section_auth,
+                nonce,
+            } => f
                 .debug_struct("OtherSection")
-                .field("elders_info", elders_info)
+                .field("section_auth", section_auth)
                 .field("nonce", nonce)
                 .finish(),
             Self::UserMessage(payload) => write!(f, "UserMessage({:10})", HexFmt(payload)),
             Self::NodeApproval {
                 genesis_key,
-                elders_info,
+                section_auth,
                 member_info,
             } => f
                 .debug_struct("NodeApproval")
                 .field("genesis_key", genesis_key)
-                .field("elders_info", elders_info)
+                .field("section_auth", section_auth)
                 .field("member_info", member_info)
                 .finish(),
             Self::Sync { section, network } => f
                 .debug_struct("Sync")
-                .field("elders_info", section.elders_info())
+                .field("section_auth", section.authority_provider())
                 .field("section_key", section.chain().last_key())
                 .field(
                     "other_prefixes",
@@ -195,11 +198,11 @@ impl Debug for Variant {
             Self::RelocatePromise(payload) => write!(f, "RelocatePromise({:?})", payload),
             Self::JoinRequest(payload) => write!(f, "JoinRequest({:?})", payload),
             Self::JoinRetry {
-                elders_info,
+                section_auth,
                 section_key,
             } => f
                 .debug_struct("JoinRetry")
-                .field("elders_info", elders_info)
+                .field("section_auth", section_auth)
                 .field("section_key", section_key)
                 .finish(),
             Self::BouncedUntrustedMessage(message) => f
@@ -213,11 +216,11 @@ impl Debug for Variant {
                 .finish(),
             Self::DkgStart {
                 dkg_key,
-                elders_info,
+                section_auth,
             } => f
                 .debug_struct("DkgStart")
                 .field("dkg_key", dkg_key)
-                .field("elders_info", elders_info)
+                .field("section_auth", section_auth)
                 .finish(),
             Self::DkgMessage { dkg_key, message } => f
                 .debug_struct("DkgMessage")

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -65,18 +65,19 @@ impl Network {
     }
 
     /// Returns all elders from all known sections.
-    pub fn elders(&self) -> impl Iterator<Item = &Peer> {
-        self.all().flat_map(|info| info.elders.values())
+    pub fn elders(&'_ self) -> impl Iterator<Item = Peer> + '_ {
+        self.all().flat_map(|info| info.peers())
     }
 
     /// Returns a `Peer` of an elder from a known section.
-    pub fn get_elder(&self, name: &XorName) -> Option<&Peer> {
+    pub fn get_elder(&self, name: &XorName) -> Option<Peer> {
         self.sections
             .get_matching(name)?
             .section_auth
             .value
             .elders
             .get(name)
+            .map(|addr| Peer::new(*name, *addr))
     }
 
     /// Merge two `Network`s into one.

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -13,7 +13,7 @@ use self::{prefix_map::PrefixMap, stats::NetworkStats};
 use crate::{
     agreement::{verify_proof, Proof, Proven},
     peer::Peer,
-    section::{EldersInfo, SectionChain},
+    section::{SectionAuthorityProvider, SectionChain},
 };
 
 use serde::{Deserialize, Serialize};
@@ -23,7 +23,7 @@ use xor_name::{Prefix, XorName};
 /// Container for storing information about other sections in the network.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Network {
-    // Other sections: maps section prefixes to their latest signed elders infos.
+    // Other sections: maps section prefixes to their latest signed section authority providers.
     sections: PrefixMap<OtherSection>,
     // BLS public keys of known sections excluding ours.
     keys: PrefixMap<Proven<(Prefix, bls::PublicKey)>>,
@@ -42,26 +42,26 @@ impl Network {
 
     /// Returns the known section that is closest to the given name, regardless of whether `name`
     /// belongs in that section or not.
-    pub fn closest(&self, name: &XorName) -> Option<&EldersInfo> {
+    pub fn closest(&self, name: &XorName) -> Option<&SectionAuthorityProvider> {
         self.all()
             .min_by(|lhs, rhs| lhs.prefix.cmp_distance(&rhs.prefix, name))
     }
 
     /// Returns iterator over all known sections.
-    pub fn all(&self) -> impl Iterator<Item = &EldersInfo> + Clone {
-        self.sections.iter().map(|info| &info.elders_info.value)
+    pub fn all(&self) -> impl Iterator<Item = &SectionAuthorityProvider> + Clone {
+        self.sections.iter().map(|info| &info.section_auth.value)
     }
 
-    /// Get `EldersInfo` of a known section with the given prefix.
-    pub fn get(&self, prefix: &Prefix) -> Option<&EldersInfo> {
+    /// Get `SectionAuthorityProvider` of a known section with the given prefix.
+    pub fn get(&self, prefix: &Prefix) -> Option<&SectionAuthorityProvider> {
         self.sections
             .get(prefix)
-            .map(|info| &info.elders_info.value)
+            .map(|info| &info.section_auth.value)
     }
 
     /// Returns prefixes of all known sections.
     pub fn prefixes(&self) -> impl Iterator<Item = &Prefix> + Clone {
-        self.all().map(|elders_info| &elders_info.prefix)
+        self.all().map(|section_auth| &section_auth.prefix)
     }
 
     /// Returns all elders from all known sections.
@@ -73,7 +73,7 @@ impl Network {
     pub fn get_elder(&self, name: &XorName) -> Option<&Peer> {
         self.sections
             .get_matching(name)?
-            .elders_info
+            .section_auth
             .value
             .elders
             .get(name)
@@ -106,7 +106,7 @@ impl Network {
 
     /// Update the info about a section.
     ///
-    /// If this is for our sibling section, then `elders_info` is signed by them and so the signing
+    /// If this is for our sibling section, then `section_auth` is signed by them and so the signing
     /// key is not in our `section_chain`. To prove the key is valid, it must be accompanied by an
     /// additional `key_proof` which signs it using a key that is present in `section_chain`.
     ///
@@ -115,12 +115,12 @@ impl Network {
     /// needed in that case.
     pub fn update_section(
         &mut self,
-        elders_info: Proven<EldersInfo>,
+        section_auth: Proven<SectionAuthorityProvider>,
         key_proof: Option<Proof>,
         section_chain: &SectionChain,
     ) -> bool {
         let info = OtherSection {
-            elders_info: elders_info.clone(),
+            section_auth: section_auth.clone(),
             key_proof,
         };
 
@@ -129,7 +129,7 @@ impl Network {
         }
 
         if let Some(old) = self.sections.insert(info) {
-            if old.elders_info == elders_info {
+            if old.section_auth == section_auth {
                 return false;
             }
         }
@@ -180,17 +180,17 @@ impl Network {
             .map(|entry| &entry.value.1)
     }
 
-    /// Returns the elders_info and the latest known key for the prefix that matches `name`,
+    /// Returns the section_auth and the latest known key for the prefix that matches `name`,
     /// excluding self section.
     pub fn section_by_name(
         &self,
         name: &XorName,
-    ) -> (Option<&bls::PublicKey>, Option<&EldersInfo>) {
+    ) -> (Option<&bls::PublicKey>, Option<&SectionAuthorityProvider>) {
         (
             self.keys.get_matching(name).map(|entry| &entry.value.1),
             self.sections
                 .get_matching(name)
-                .map(|entry| &entry.elders_info.value),
+                .map(|entry| &entry.section_auth.value),
         )
     }
 
@@ -215,7 +215,7 @@ impl Network {
     }
 
     /// Returns network statistics.
-    pub fn network_stats(&self, our: &EldersInfo) -> NetworkStats {
+    pub fn network_stats(&self, our: &SectionAuthorityProvider) -> NetworkStats {
         let (known_elders, total_elders, total_elders_exact) = self.network_elder_counts(our);
 
         NetworkStats {
@@ -230,7 +230,7 @@ impl Network {
     //
     // Return (known, total, exact), where `exact` indicates whether `total` is an exact number of
     // an estimate.
-    fn network_elder_counts(&self, our: &EldersInfo) -> (u64, u64, bool) {
+    fn network_elder_counts(&self, our: &SectionAuthorityProvider) -> (u64, u64, bool) {
         let known_prefixes = iter::once(&our.prefix).chain(self.prefixes());
         let is_exact = Prefix::default().is_covered_by(known_prefixes.clone());
 
@@ -252,7 +252,7 @@ struct OtherSection {
     // If this is signed by our section, then `key_proof` is `None`. If this is signed by our
     // sibling section, then `key_proof` contains the proof of the signing key itself signed by our
     // section.
-    elders_info: Proven<EldersInfo>,
+    section_auth: Proven<SectionAuthorityProvider>,
     key_proof: Option<Proof>,
 }
 
@@ -260,17 +260,17 @@ impl OtherSection {
     fn verify(&self, section_chain: &SectionChain) -> bool {
         if let Some(key_proof) = &self.key_proof {
             section_chain.has_key(&key_proof.public_key)
-                && verify_proof(key_proof, &self.elders_info.proof.public_key)
-                && self.elders_info.self_verify()
+                && verify_proof(key_proof, &self.section_auth.proof.public_key)
+                && self.section_auth.self_verify()
         } else {
-            self.elders_info.verify(section_chain)
+            self.section_auth.verify(section_chain)
         }
     }
 }
 
 impl Borrow<Prefix> for OtherSection {
     fn borrow(&self) -> &Prefix {
-        &self.elders_info.value.prefix
+        &self.section_auth.value.prefix
     }
 }
 
@@ -403,8 +403,8 @@ mod tests {
 
         // Create map containing sections (00), (01) and (10)
         let mut map = Network::new();
-        let _ = map.update_section(gen_proven_elders_info(&sk, p01), None, &chain);
-        let _ = map.update_section(gen_proven_elders_info(&sk, p10), None, &chain);
+        let _ = map.update_section(gen_proven_section_auth(&sk, p01), None, &chain);
+        let _ = map.update_section(gen_proven_section_auth(&sk, p10), None, &chain);
 
         let mut rng = rand::thread_rng();
         let n01 = p01.substituted_in(rng.gen());
@@ -474,9 +474,12 @@ mod tests {
         }
     }
 
-    fn gen_proven_elders_info(sk: &bls::SecretKey, prefix: Prefix) -> Proven<EldersInfo> {
-        let (elders_info, _) = section::test_utils::gen_elders_info(prefix, 5);
-        agreement::test_utils::proven(sk, elders_info).unwrap()
+    fn gen_proven_section_auth(
+        sk: &bls::SecretKey,
+        prefix: Prefix,
+    ) -> Proven<SectionAuthorityProvider> {
+        let (section_auth, _) = section::test_utils::gen_section_authority_provider(prefix, 5);
+        agreement::test_utils::proven(sk, section_auth).unwrap()
     }
 
     fn gen_key() -> bls::PublicKey {

--- a/src/relocation.rs
+++ b/src/relocation.rs
@@ -291,7 +291,7 @@ mod tests {
     use crate::{
         agreement::test_utils::proven,
         peer::test_utils::arbitrary_unique_peers,
-        section::{EldersInfo, SectionChain},
+        section::{SectionAuthorityProvider, SectionChain},
         ELDER_SIZE, MIN_AGE,
     };
     use anyhow::Result;
@@ -338,7 +338,7 @@ mod tests {
 
         // Create `Section` with `peers` as its members and set the `ELDER_SIZE` oldest peers as
         // the elders.
-        let elders_info = EldersInfo::new(
+        let section_auth = SectionAuthorityProvider::new(
             peers
                 .iter()
                 .sorted_by_key(|peer| peer.age())
@@ -347,9 +347,9 @@ mod tests {
                 .copied(),
             Prefix::default(),
         );
-        let elders_info = proven(&sk, elders_info)?;
+        let section_auth = proven(&sk, section_auth)?;
 
-        let mut section = Section::new(pk, SectionChain::new(pk), elders_info)?;
+        let mut section = Section::new(pk, SectionChain::new(pk), section_auth)?;
 
         for peer in &peers {
             let info = MemberInfo::joined(*peer);

--- a/src/routing/bootstrap.rs
+++ b/src/routing/bootstrap.rs
@@ -13,7 +13,6 @@ use crate::{
     error::{Error, Result},
     messages::{JoinRequest, Message, ResourceProofResponse, Variant, VerifyStatus},
     node::Node,
-    peer::Peer,
     relocation::{RelocatePayload, SignedRelocateDetails},
     section::{Section, SectionAuthorityProvider, SectionChain},
 };
@@ -334,7 +333,7 @@ impl<'a> State<'a> {
                             relocate_payload: relocate_payload.clone(),
                             resource_proof_response: None,
                         };
-                        let recipients = section_auth.peers().map(Peer::addr).copied().collect();
+                        let recipients = section_auth.elders.values().copied().collect();
                         self.send_join_requests(join_request, recipients).await?;
                     } else {
                         warn!(
@@ -671,7 +670,7 @@ mod tests {
             let message = assert_matches!(message, MessageType::NodeMessage(NodeMessage(bytes)) =>
                 Message::from_bytes(Bytes::from(bytes))?);
 
-            itertools::assert_equal(&recipients, section_auth.peers().map(Peer::addr));
+            itertools::assert_equal(&recipients, section_auth.elders.values());
             assert_matches!(message.variant(), Variant::JoinRequest(request) => {
                 assert_eq!(request.section_key, pk);
                 assert!(request.relocate_payload.is_none());

--- a/src/routing/command.rs
+++ b/src/routing/command.rs
@@ -10,7 +10,7 @@ use crate::{
     agreement::{DkgFailureProofSet, Proposal},
     messages::Message,
     relocation::SignedRelocateDetails,
-    section::{EldersInfo, SectionKeyShare},
+    section::{SectionAuthorityProvider, SectionKeyShare},
 };
 use bls_signature_aggregator::Proof;
 use bytes::Bytes;
@@ -53,7 +53,7 @@ pub(crate) enum Command {
     /// Handle the outcome of a DKG session where we are one of the participants (that is, one of
     /// the proposed new elders).
     HandleDkgOutcome {
-        elders_info: EldersInfo,
+        section_auth: SectionAuthorityProvider,
         outcome: SectionKeyShare,
     },
     /// Handle a DKG failure that was observed by a majority of the DKG participants.
@@ -131,11 +131,11 @@ impl Debug for Command {
                 .field("proof.public_key", &proof.public_key)
                 .finish(),
             Self::HandleDkgOutcome {
-                elders_info,
+                section_auth,
                 outcome,
             } => f
                 .debug_struct("HandleDkgOutcome")
-                .field("elders_info", elders_info)
+                .field("section_auth", section_auth)
                 .field("outcome", &outcome.public_key_set.public_key())
                 .finish(),
             Self::HandleDkgFailure(proofs) => {

--- a/src/routing/dispatcher.rs
+++ b/src/routing/dispatcher.rs
@@ -114,13 +114,13 @@ impl Dispatcher {
                 .collect()),
             Command::HandlePeerLost(addr) => self.core.lock().await.handle_peer_lost(&addr),
             Command::HandleDkgOutcome {
-                elders_info,
+                section_auth,
                 outcome,
             } => self
                 .core
                 .lock()
                 .await
-                .handle_dkg_outcome(elders_info, outcome),
+                .handle_dkg_outcome(section_auth, outcome),
             Command::HandleDkgFailure(proofs) => self
                 .core
                 .lock()

--- a/src/routing/lazy_messaging.rs
+++ b/src/routing/lazy_messaging.rs
@@ -42,7 +42,7 @@ pub(crate) fn process(
             // `OtherSection` with their latest info, including their latest key.
             //
             // NOTE: the reason why we update the key only after receiving their `OtherSection` and
-            // not right here is to keep their key and their elders info in sync.
+            // not right here is to keep their key and their section_authority_provider in sync.
             trace!("lazy messaging: src key unknown");
             send_other_section = true;
         }
@@ -108,7 +108,7 @@ fn create_other_section_message(
         .minimize(vec![section.chain().last_key(), dst_knowledge])?;
 
     let variant = Variant::OtherSection {
-        elders_info: section.proven_elders_info().clone(),
+        section_auth: section.proven_authority_provider().clone(),
         nonce,
     };
 
@@ -136,7 +136,7 @@ mod tests {
         agreement::test_utils::proven,
         crypto,
         section::{
-            test_utils::{gen_addr, gen_elders_info},
+            test_utils::{gen_addr, gen_section_authority_provider},
             SectionChain,
         },
         ELDER_SIZE, MIN_AGE,
@@ -189,8 +189,8 @@ mod tests {
         assert_matches!(&actions.send, Some(message) => {
             assert_matches!(
                 message.variant(),
-                Variant::OtherSection { elders_info, .. } => {
-                    assert_eq!(&elders_info.value, env.section.elders_info())
+                Variant::OtherSection { section_auth, .. } => {
+                    assert_eq!(&section_auth.value, env.section.authority_provider())
                 }
             );
             assert_eq!(message.dst_key(), Some(&their_old_pk));
@@ -315,22 +315,22 @@ mod tests {
             let (chain, our_sk) =
                 create_chain(chain_len).context("failed to create section chain")?;
 
-            let (elders_info0, mut nodes) = gen_elders_info(prefix0, ELDER_SIZE);
+            let (section_auth0, mut nodes) = gen_section_authority_provider(prefix0, ELDER_SIZE);
             let node = nodes.remove(0);
 
-            let elders_info0 = proven(&our_sk, elders_info0)?;
-            let section = Section::new(*chain.root_key(), chain, elders_info0)
+            let section_auth0 = proven(&our_sk, section_auth0)?;
+            let section = Section::new(*chain.root_key(), chain, section_auth0)
                 .context("failed to create section")?;
 
-            let (elders_info1, _) = gen_elders_info(prefix1, ELDER_SIZE);
-            let elders_info1 = proven(&our_sk, elders_info1)?;
+            let (section_auth1, _) = gen_section_authority_provider(prefix1, ELDER_SIZE);
+            let section_auth1 = proven(&our_sk, section_auth1)?;
 
             let their_sk = bls::SecretKey::random();
             let their_pk = their_sk.public_key();
             let key1 = proven(&our_sk, (prefix1, their_pk))?;
 
             let mut network = Network::new();
-            assert!(network.update_section(elders_info1, None, section.chain()));
+            assert!(network.update_section(section_auth1, None, section.chain()));
             assert!(network.update_their_key(key1));
 
             Ok(Self {

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -232,7 +232,6 @@ impl Routing {
             .section()
             .authority_provider()
             .peers()
-            .copied()
             .collect()
     }
 

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     messages::Message,
     node::Node,
     peer::Peer,
-    section::{EldersInfo, SectionChain},
+    section::{SectionAuthorityProvider, SectionChain},
     TransportConfig, MIN_AGE,
 };
 use bytes::Bytes;
@@ -230,7 +230,7 @@ impl Routing {
             .lock()
             .await
             .section()
-            .elders_info()
+            .authority_provider()
             .peers()
             .copied()
             .collect()
@@ -268,18 +268,18 @@ impl Routing {
     }
 
     /// Returns the info about our section or `None` if we are not joined yet.
-    pub async fn our_section(&self) -> EldersInfo {
+    pub async fn our_section(&self) -> SectionAuthorityProvider {
         self.dispatcher
             .core
             .lock()
             .await
             .section()
-            .elders_info()
+            .authority_provider()
             .clone()
     }
 
     /// Returns the info about other sections in the network known to us.
-    pub async fn other_sections(&self) -> Vec<EldersInfo> {
+    pub async fn other_sections(&self) -> Vec<SectionAuthorityProvider> {
         self.dispatcher
             .core
             .lock()
@@ -304,10 +304,10 @@ impl Routing {
     pub async fn matching_section(
         &self,
         name: &XorName,
-    ) -> (Option<bls::PublicKey>, Option<EldersInfo>) {
+    ) -> (Option<bls::PublicKey>, Option<SectionAuthorityProvider>) {
         let state = self.dispatcher.core.lock().await;
-        let (key, elders_info) = state.matching_section(name);
-        (key.copied(), elders_info.cloned())
+        let (key, section_auth) = state.matching_section(name);
+        (key.copied(), section_auth.cloned())
     }
 
     /// Send a message.

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -81,7 +81,7 @@ impl Section {
         )?;
 
         for peer in section.section_auth.value.peers() {
-            let member_info = MemberInfo::joined(*peer);
+            let member_info = MemberInfo::joined(peer);
             let proof = create_first_proof(&public_key_set, &secret_key_share, &member_info)?;
             let _ = section.members.update(Proven {
                 value: member_info,

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -6,18 +6,18 @@
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
 
-mod elders_info;
 mod member_info;
+mod section_authority_provider;
 mod section_chain;
 mod section_keys;
 mod section_peers;
 
 #[cfg(test)]
-pub(crate) use self::elders_info::test_utils;
+pub(crate) use self::section_authority_provider::test_utils;
 pub(crate) use self::section_peers::SectionPeers;
 pub use self::{
-    elders_info::EldersInfo,
     member_info::{MemberInfo, PeerState, MIN_AGE},
+    section_authority_provider::SectionAuthorityProvider,
     section_chain::{Error as SectionChainError, SectionChain},
     section_keys::{SectionKeyShare, SectionKeysProvider},
 };
@@ -37,22 +37,22 @@ use xor_name::{Prefix, XorName};
 pub(crate) struct Section {
     genesis_key: bls::PublicKey,
     chain: SectionChain,
-    elders_info: Proven<EldersInfo>,
+    section_auth: Proven<SectionAuthorityProvider>,
     members: SectionPeers,
 }
 
 impl Section {
     /// Creates a minimal `Section` initially containing only info about our elders
-    /// (`elders_info`).
+    /// (`section_auth`).
     ///
-    /// Returns error if `elders_info` is not signed with the last key of `chain`.
+    /// Returns error if `section_auth` is not signed with the last key of `chain`.
     pub fn new(
         genesis_key: bls::PublicKey,
         chain: SectionChain,
-        elders_info: Proven<EldersInfo>,
+        section_auth: Proven<SectionAuthorityProvider>,
     ) -> Result<Self, Error> {
-        if elders_info.proof.public_key != *chain.last_key() {
-            error!("can't create section: elders_info signed with incorrect key");
+        if section_auth.proof.public_key != *chain.last_key() {
+            error!("can't create section: section_auth signed with incorrect key");
             // TODO: consider more specific error here.
             return Err(Error::InvalidMessage);
         }
@@ -60,7 +60,7 @@ impl Section {
         Ok(Self {
             genesis_key,
             chain,
-            elders_info,
+            section_auth,
             members: SectionPeers::default(),
         })
     }
@@ -71,15 +71,16 @@ impl Section {
         let public_key_set = secret_key_set.public_keys();
         let secret_key_share = secret_key_set.secret_key_share(0);
 
-        let elders_info = create_first_elders_info(&public_key_set, &secret_key_share, peer)?;
+        let section_auth =
+            create_first_section_authority_provider(&public_key_set, &secret_key_share, peer)?;
 
         let mut section = Self::new(
-            elders_info.proof.public_key,
-            SectionChain::new(elders_info.proof.public_key),
-            elders_info,
+            section_auth.proof.public_key,
+            SectionChain::new(section_auth.proof.public_key),
+            section_auth,
         )?;
 
-        for peer in section.elders_info.value.peers() {
+        for peer in section.section_auth.value.peers() {
             let member_info = MemberInfo::joined(*peer);
             let proof = create_first_proof(&public_key_set, &secret_key_share, &member_info)?;
             let _ = section.members.update(Proven {
@@ -104,20 +105,20 @@ impl Section {
     /// Try to merge this `Section` with `other`. Returns `InvalidMessage` if `other` is invalid or
     /// its chain is not compatible with the chain of `self`.
     pub fn merge(&mut self, other: Self) -> Result<()> {
-        if !other.elders_info.self_verify() {
-            error!("can't merge sections: other elders_info failed self-verification");
+        if !other.section_auth.self_verify() {
+            error!("can't merge sections: other section_auth failed self-verification");
             return Err(Error::InvalidMessage);
         }
-        if &other.elders_info.proof.public_key != other.chain.last_key() {
+        if &other.section_auth.proof.public_key != other.chain.last_key() {
             // TODO: use more specific error variant.
-            error!("can't merge sections: other elders_info signed with incorrect key");
+            error!("can't merge sections: other section_auth signed with incorrect key");
             return Err(Error::InvalidMessage);
         }
 
         self.chain.merge(other.chain.clone())?;
 
-        if &other.elders_info.proof.public_key == self.chain.last_key() {
-            self.elders_info = other.elders_info;
+        if &other.section_auth.proof.public_key == self.chain.last_key() {
+            self.section_auth = other.section_auth;
         }
 
         for info in other.members {
@@ -125,45 +126,45 @@ impl Section {
         }
 
         self.members
-            .prune_not_matching(&self.elders_info.value.prefix);
+            .prune_not_matching(&self.section_auth.value.prefix);
 
         Ok(())
     }
 
-    /// Update the `EldersInfo` of our section.
+    /// Update the `SectionAuthorityProvider` of our section.
     pub fn update_elders(
         &mut self,
-        new_elders_info: Proven<EldersInfo>,
+        new_section_auth: Proven<SectionAuthorityProvider>,
         new_key_proof: Proof,
     ) -> bool {
-        if new_elders_info.value.prefix != *self.prefix()
-            && !new_elders_info.value.prefix.is_extension_of(self.prefix())
+        if new_section_auth.value.prefix != *self.prefix()
+            && !new_section_auth.value.prefix.is_extension_of(self.prefix())
         {
             return false;
         }
 
-        if !new_elders_info.self_verify() {
+        if !new_section_auth.self_verify() {
             return false;
         }
 
         if let Err(error) = self.chain.insert(
             &new_key_proof.public_key,
-            new_elders_info.proof.public_key,
+            new_section_auth.proof.public_key,
             new_key_proof.signature,
         ) {
             error!(
                 "failed to insert key {:?} (signed with {:?}) into the section chain: {}",
-                new_elders_info.proof.public_key, new_key_proof.public_key, error,
+                new_section_auth.proof.public_key, new_key_proof.public_key, error,
             );
             return false;
         }
 
-        if &new_elders_info.proof.public_key == self.chain.last_key() {
-            self.elders_info = new_elders_info;
+        if &new_section_auth.proof.public_key == self.chain.last_key() {
+            self.section_auth = new_section_auth;
         }
 
         self.members
-            .prune_not_matching(&self.elders_info.value.prefix);
+            .prune_not_matching(&self.section_auth.value.prefix);
 
         true
     }
@@ -177,13 +178,14 @@ impl Section {
         self.members.update(member_info)
     }
 
-    // Returns a trimmed version of this `Section` which contains only the elders info and the
-    // section chain truncated to the given length (the chain is truncated from the end, so it
-    // always contains the latest key). If `chain_len` is zero, it is silently replaced with one.
+    // Returns a trimmed version of this `Section` which contains only the section authority
+    // provider and the section chain truncated to the given length (the chain is truncated from
+    // the end, so it always contains the latest key). If `chain_len` is zero, it is silently
+    // replaced with one.
     pub fn trimmed(&self, chain_len: usize) -> Self {
         Self {
             genesis_key: self.genesis_key,
-            elders_info: self.elders_info.clone(),
+            section_auth: self.section_auth.clone(),
             chain: self.chain.truncate(chain_len),
             members: SectionPeers::default(),
         }
@@ -211,34 +213,34 @@ impl Section {
 
         Ok(Self {
             genesis_key: self.genesis_key,
-            elders_info: self.elders_info.clone(),
+            section_auth: self.section_auth.clone(),
             chain,
             members: self.members.clone(),
         })
     }
 
-    pub fn elders_info(&self) -> &EldersInfo {
-        &self.elders_info.value
+    pub fn authority_provider(&self) -> &SectionAuthorityProvider {
+        &self.section_auth.value
     }
 
-    pub fn proven_elders_info(&self) -> &Proven<EldersInfo> {
-        &self.elders_info
+    pub fn proven_authority_provider(&self) -> &Proven<SectionAuthorityProvider> {
+        &self.section_auth
     }
 
     pub fn is_elder(&self, name: &XorName) -> bool {
-        self.elders_info().elders.contains_key(name)
+        self.authority_provider().elders.contains_key(name)
     }
 
     /// Generate a new section info(s) based on the current set of members.
-    /// Returns a set of candidate EldersInfos.
-    pub fn promote_and_demote_elders(&self, our_name: &XorName) -> Vec<EldersInfo> {
+    /// Returns a set of candidate SectionAuthorityProviders.
+    pub fn promote_and_demote_elders(&self, our_name: &XorName) -> Vec<SectionAuthorityProvider> {
         if let Some((our_info, other_info)) = self.try_split(our_name) {
             return vec![our_info, other_info];
         }
 
         let expected_peers = self.elder_candidates(ELDER_SIZE);
         let expected_names: BTreeSet<_> = expected_peers.iter().map(Peer::name).collect();
-        let current_names: BTreeSet<_> = self.elders_info().elders.keys().collect();
+        let current_names: BTreeSet<_> = self.authority_provider().elders.keys().collect();
 
         if expected_names == current_names {
             vec![]
@@ -246,14 +248,15 @@ impl Section {
             warn!("ignore attempt to reduce the number of elders too much");
             vec![]
         } else {
-            let new_info = EldersInfo::new(expected_peers, self.elders_info().prefix);
+            let new_info =
+                SectionAuthorityProvider::new(expected_peers, self.authority_provider().prefix);
             vec![new_info]
         }
     }
 
     // Prefix of our section.
     pub fn prefix(&self) -> &Prefix {
-        &self.elders_info().prefix
+        &self.authority_provider().prefix
     }
 
     pub fn members(&self) -> &SectionPeers {
@@ -285,9 +288,12 @@ impl Section {
     }
 
     // Tries to split our section.
-    // If we have enough mature nodes for both subsections, returns the elders infos of the two
-    // subsections. Otherwise returns `None`.
-    fn try_split(&self, our_name: &XorName) -> Option<(EldersInfo, EldersInfo)> {
+    // If we have enough mature nodes for both subsections, returns the SectionAuthorityProviders
+    // of the two subsections. Otherwise returns `None`.
+    fn try_split(
+        &self,
+        our_name: &XorName,
+    ) -> Option<(SectionAuthorityProvider, SectionAuthorityProvider)> {
         let next_bit_index = if let Ok(index) = self.prefix().bit_count().try_into() {
             index
         } else {
@@ -320,16 +326,16 @@ impl Section {
         let our_elders = self.members.elder_candidates_matching_prefix(
             &our_prefix,
             ELDER_SIZE,
-            self.elders_info(),
+            self.authority_provider(),
         );
         let other_elders = self.members.elder_candidates_matching_prefix(
             &other_prefix,
             ELDER_SIZE,
-            self.elders_info(),
+            self.authority_provider(),
         );
 
-        let our_info = EldersInfo::new(our_elders, our_prefix);
-        let other_info = EldersInfo::new(other_elders, other_prefix);
+        let our_info = SectionAuthorityProvider::new(our_elders, our_prefix);
+        let other_info = SectionAuthorityProvider::new(other_elders, other_prefix);
 
         Some((our_info, other_info))
     }
@@ -338,19 +344,19 @@ impl Section {
     // relocating nodes if there would not be enough instead.
     fn elder_candidates(&self, elder_size: usize) -> Vec<Peer> {
         self.members
-            .elder_candidates(elder_size, self.elders_info())
+            .elder_candidates(elder_size, self.authority_provider())
     }
 }
 
-// Create `EldersInfo` for the first node.
-fn create_first_elders_info(
+// Create `SectionAuthorityProvider` for the first node.
+fn create_first_section_authority_provider(
     pk_set: &bls::PublicKeySet,
     sk_share: &bls::SecretKeyShare,
     peer: Peer,
-) -> Result<Proven<EldersInfo>> {
-    let elders_info = EldersInfo::new(iter::once(peer), Prefix::default());
-    let proof = create_first_proof(pk_set, sk_share, &elders_info)?;
-    Ok(Proven::new(elders_info, proof))
+) -> Result<Proven<SectionAuthorityProvider>> {
+    let section_auth = SectionAuthorityProvider::new(iter::once(peer), Prefix::default());
+    let proof = create_first_proof(pk_set, sk_share, &section_auth)?;
+    Ok(Proven::new(section_auth, proof))
 }
 
 fn create_first_proof<T: Serialize>(

--- a/src/section/section_authority_provider.rs
+++ b/src/section/section_authority_provider.rs
@@ -16,18 +16,18 @@ use std::{
 };
 
 /// The information about all elders of a section at one point in time. Each elder is always a
-/// member of exactly one current section, but a new `EldersInfo` is created whenever the elders
+/// member of exactly one current section, but a new `SectionAuthorityProvider` is created whenever the elders
 /// change, due to an elder being added or removed, or the section splitting or merging.
 #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
-pub struct EldersInfo {
+pub struct SectionAuthorityProvider {
     /// The section's complete set of elders as a map from their name to a `Peer`.
     pub elders: BTreeMap<XorName, Peer>,
     /// The section prefix. It matches all the members' names.
     pub prefix: Prefix,
 }
 
-impl EldersInfo {
-    /// Creates a new `EldersInfo` with the given members, prefix and version.
+impl SectionAuthorityProvider {
+    /// Creates a new `SectionAuthorityProvider` with the given members, prefix and version.
     pub fn new<I>(elders: I, prefix: Prefix) -> Self
     where
         I: IntoIterator<Item = Peer>,
@@ -55,24 +55,24 @@ impl EldersInfo {
     }
 }
 
-impl Borrow<Prefix> for EldersInfo {
+impl Borrow<Prefix> for SectionAuthorityProvider {
     fn borrow(&self) -> &Prefix {
         &self.prefix
     }
 }
 
-impl Debug for EldersInfo {
+impl Debug for SectionAuthorityProvider {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         write!(
             formatter,
-            "EldersInfo {{ prefix: ({:b}), elders: {{{:?}}} }}",
+            "SectionAuthorityProvider {{ prefix: ({:b}), elders: {{{:?}}} }}",
             self.prefix,
             self.elders.values().format(", "),
         )
     }
 }
 
-impl Display for EldersInfo {
+impl Display for SectionAuthorityProvider {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
@@ -85,7 +85,7 @@ impl Display for EldersInfo {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use super::EldersInfo;
+    use super::SectionAuthorityProvider;
     use crate::{crypto, node::Node, MIN_AGE};
     use itertools::Itertools;
     use std::{cell::Cell, net::SocketAddr};
@@ -123,16 +123,19 @@ pub(crate) mod test_utils {
             .collect()
     }
 
-    // Generate random `EldersInfo` for testing purposes.
-    pub(crate) fn gen_elders_info(prefix: Prefix, count: usize) -> (EldersInfo, Vec<Node>) {
+    // Generate random `SectionAuthorityProvider` for testing purposes.
+    pub(crate) fn gen_section_authority_provider(
+        prefix: Prefix,
+        count: usize,
+    ) -> (SectionAuthorityProvider, Vec<Node>) {
         let nodes = gen_sorted_nodes(&prefix, count, false);
         let elders = nodes
             .iter()
             .map(Node::peer)
             .map(|peer| (*peer.name(), peer))
             .collect();
-        let elders_info = EldersInfo { elders, prefix };
+        let section_auth = SectionAuthorityProvider { elders, prefix };
 
-        (elders_info, nodes)
+        (section_auth, nodes)
     }
 }

--- a/src/section/section_authority_provider.rs
+++ b/src/section/section_authority_provider.rs
@@ -13,6 +13,7 @@ use std::{
     borrow::Borrow,
     collections::BTreeMap,
     fmt::{self, Debug, Display, Formatter},
+    net::SocketAddr,
 };
 
 /// The information about all elders of a section at one point in time. Each elder is always a
@@ -20,8 +21,8 @@ use std::{
 /// change, due to an elder being added or removed, or the section splitting or merging.
 #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
 pub struct SectionAuthorityProvider {
-    /// The section's complete set of elders as a map from their name to a `Peer`.
-    pub elders: BTreeMap<XorName, Peer>,
+    /// The section's complete set of elders as a map from their name to their socket address.
+    pub elders: BTreeMap<XorName, SocketAddr>,
     /// The section prefix. It matches all the members' names.
     pub prefix: Prefix,
 }
@@ -35,16 +36,18 @@ impl SectionAuthorityProvider {
         Self {
             elders: elders
                 .into_iter()
-                .map(|peer| (*peer.name(), peer))
+                .map(|peer| (*peer.name(), *peer.addr()))
                 .collect(),
             prefix,
         }
     }
 
     pub(crate) fn peers(
-        &self,
-    ) -> impl Iterator<Item = &Peer> + DoubleEndedIterator + ExactSizeIterator + Clone {
-        self.elders.values()
+        &'_ self,
+    ) -> impl Iterator<Item = Peer> + DoubleEndedIterator + ExactSizeIterator + Clone + '_ {
+        self.elders
+            .iter()
+            .map(|(name, addr)| Peer::new(*name, *addr))
     }
 
     /// Returns the index of the elder with `name` in this set of elders.
@@ -132,7 +135,7 @@ pub(crate) mod test_utils {
         let elders = nodes
             .iter()
             .map(Node::peer)
-            .map(|peer| (*peer.name(), peer))
+            .map(|peer| (*peer.name(), *peer.addr()))
             .collect();
         let section_auth = SectionAuthorityProvider { elders, prefix };
 

--- a/src/section/section_peers.rs
+++ b/src/section/section_peers.rs
@@ -8,7 +8,7 @@
 
 use super::{
     member_info::{MemberInfo, PeerState},
-    EldersInfo,
+    SectionAuthorityProvider,
 };
 use crate::{agreement::Proven, peer::Peer};
 
@@ -63,7 +63,11 @@ impl SectionPeers {
     }
 
     /// Returns the candidates for elders out of all the nodes in this section.
-    pub fn elder_candidates(&self, elder_size: usize, current_elders: &EldersInfo) -> Vec<Peer> {
+    pub fn elder_candidates(
+        &self,
+        elder_size: usize,
+        current_elders: &SectionAuthorityProvider,
+    ) -> Vec<Peer> {
         elder_candidates(
             elder_size,
             current_elders,
@@ -78,7 +82,7 @@ impl SectionPeers {
         &self,
         prefix: &Prefix,
         elder_size: usize,
-        current_elders: &EldersInfo,
+        current_elders: &SectionAuthorityProvider,
     ) -> Vec<Peer> {
         elder_candidates(
             elder_size,
@@ -169,7 +173,11 @@ impl IntoIterator for SectionPeers {
 // Returns the nodes that should become the next elders out of the given members, sorted by names.
 // It is assumed that `members` contains only "active" peers (see the `is_active` function below
 // for explanation)
-fn elder_candidates<'a, I>(elder_size: usize, current_elders: &EldersInfo, members: I) -> Vec<Peer>
+fn elder_candidates<'a, I>(
+    elder_size: usize,
+    current_elders: &SectionAuthorityProvider,
+    members: I,
+) -> Vec<Peer>
 where
     I: IntoIterator<Item = &'a Proven<MemberInfo>>,
 {
@@ -185,7 +193,7 @@ where
 fn cmp_elder_candidates(
     lhs: &Proven<MemberInfo>,
     rhs: &Proven<MemberInfo>,
-    current_elders: &EldersInfo,
+    current_elders: &SectionAuthorityProvider,
 ) -> Ordering {
     // Older nodes are preferred. In case of a tie, prefer current elders. If still a tie, break
     // it comparing by the proof signatures because it's impossible for a node to predict its
@@ -222,7 +230,7 @@ fn cmp_elder_candidates_by_peer_state(lhs: &PeerState, rhs: &PeerState) -> Order
 // A peer is considered active if either it is joined or it is a current elder who is being
 // relocated. This is because such elder still fulfils its duties and only when demoted can it
 // leave.
-fn is_active(info: &MemberInfo, current_elders: &EldersInfo) -> bool {
+fn is_active(info: &MemberInfo, current_elders: &SectionAuthorityProvider) -> bool {
     match info.state {
         PeerState::Joined => true,
         PeerState::Relocated(_) if is_elder(info, current_elders) => true,
@@ -230,6 +238,6 @@ fn is_active(info: &MemberInfo, current_elders: &EldersInfo) -> bool {
     }
 }
 
-fn is_elder(info: &MemberInfo, current_elders: &EldersInfo) -> bool {
+fn is_elder(info: &MemberInfo, current_elders: &SectionAuthorityProvider) -> bool {
     current_elders.elders.contains_key(info.peer.name())
 }


### PR DESCRIPTION
TODO: 
- add section key to `SectionAuthorityProvider`
- remove `Network::keys` as the keys will be part of the section auth. provider. Also remove `Proposal::TheirKey`. 
- eventually move `SectionAuthorityProvider` to sn-messaging and use it in `SectionInfoResponse` too.