### PR TITLE
refactor(comm): change return of `send` to reflect the logic of delivery_group_size

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ use crate::{
     messages::{CreateError, ExtendProofChainError},
     section::SectionChainError,
 };
+use std::net::SocketAddr;
 use thiserror::Error;
 
 /// The type returned by the sn_routing message handling methods.
@@ -24,6 +25,14 @@ pub enum Error {
     FailedSignature,
     #[error("Cannot route.")]
     CannotRoute,
+    #[error("Empty recipient list")]
+    EmptyRecipientList,
+    #[error("The config is invalid")]
+    InvalidConfig,
+    #[error("Cannot connect to the endpoint")]
+    CannotConnectEndpoint,
+    #[error("Address not reachable")]
+    AddressNotReachable,
     #[error("Network layer error: {0}")]
     Network(#[from] qp2p::Error),
     #[error("The node is not in a state to handle the action.")]
@@ -38,8 +47,10 @@ pub enum Error {
     InvalidSignatureShare,
     #[error("The secret key share is missing.")]
     MissingSecretKeyShare,
-    #[error("Failed to send a message.")]
-    FailedSend,
+    #[error("Failed to send a message to {0}")]
+    FailedSend(SocketAddr),
+    #[error("Connection closed locally")]
+    ConnectionClosed,
     #[error("Invalid section chain: {0}")]
     InvalidSectionChain(#[from] SectionChainError),
     #[error("Messaging protocol error: {0}")]

--- a/src/routing/core.rs
+++ b/src/routing/core.rs
@@ -1108,7 +1108,7 @@ impl Core {
             };
             if recipients.is_empty() {
                 trace!("Cannot route user message, recipient list empty: {:?}", msg);
-                return Err(Error::CannotRoute);
+                return Err(Error::EmptyRecipientList);
             };
             trace!("sending user message {:?} to client {:?}", msg, recipients);
             return Ok(vec![Command::SendMessage {


### PR DESCRIPTION
 change return of `send` to reflect the logic of delivery_group_size `delivery_group_size` or not

~~BREAKING CHANGE: return type of `Comm::send` is now `Result<SendStatus>`~~