### PR TITLE
refactor(event): add SectionSplit, increase granularity

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -236,14 +236,23 @@ async fn handle_event(index: usize, node: &mut Routing, event: Event) -> bool {
         Event::MemberLeft { name, age } => {
             info!("Node #{} member left - name: {}, age: {}", index, name, age);
         }
-        Event::EldersChanged {
+        Event::SectionSplit {
             elders,
             sibling_elders,
             self_status_change,
         } => {
             info!(
-                "Node #{} elders changed - prefix: {:b}, key: {:?}, sibling elders: {:?}, elders: {:?}, node elder status change: {:?}",
-                index, elders.prefix, elders.key, sibling_elders, elders.elders, self_status_change
+                "Node #{} section split - elders: {:?}, sibling elders: {:?}, node elder status change: {:?}",
+                index, elders, sibling_elders, self_status_change
+            );
+        }
+        Event::EldersChanged {
+            elders,
+            self_status_change,
+        } => {
+            info!(
+                "Node #{} elders changed - elders: {:?}, node elder status change: {:?}",
+                index, elders, self_status_change
             );
         }
         Event::MessageReceived {
@@ -275,8 +284,15 @@ async fn handle_event(index: usize, node: &mut Routing, event: Event) -> bool {
             index, user, msg
         ),
         Event::ClientLost(addr) => info!("Node #{} received ClientLost({:?})", index, addr),
-        Event::AdultsChanged(adult_list) => {
-            info!("Node #{} received AdultsChanged({:?})", index, adult_list)
+        Event::AdultsChanged {
+            existing,
+            added,
+            removed,
+        } => {
+            info!(
+                "Node #{} adults changed - existing: {:?}, added: {:?}, removed: {:?}",
+                index, existing, added, removed
+            )
         }
     }
 

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -313,10 +313,10 @@ impl Network {
                     {
                         *prefix = elders.prefix;
 
-                        if elders.elders.contains(name) {
+                        if elders.added.iter().any(|p| p.name() == name) {
                             *elder = Some(ElderState {
                                 key: elders.key,
-                                num_elders: elders.elders.len(),
+                                num_elders: elders.existing.len() + elders.added.len(),
                             });
                         } else {
                             *elder = None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ extern crate tracing;
 pub use self::{
     error::{Error, Result},
     event::{Event, NodeElderChange, SendStream},
+    peer::Peer,
     routing::{Config, EventStream, Routing},
     section::{
         SectionChain, SectionChainError, FIRST_SECTION_MAX_AGE, FIRST_SECTION_MIN_AGE,

--- a/src/routing/core/mod.rs
+++ b/src/routing/core/mod.rs
@@ -22,12 +22,14 @@ use crate::{
     messages::Message,
     network::Network,
     node::Node,
+    peer::Peer,
     relocation::RelocateState,
     section::{Section, SectionKeyShare, SectionKeysProvider},
 };
 use bls_signature_aggregator::SignatureAggregator;
 use itertools::Itertools;
 use resource_proof::ResourceProof;
+use std::collections::BTreeSet;
 use tokio::sync::mpsc;
 use xor_name::{Prefix, XorName};
 
@@ -113,6 +115,7 @@ impl Core {
             is_elder: self.is_elder(),
             last_key: *self.section.chain().last_key(),
             prefix: *self.section.prefix(),
+            elders: self.section().elders().copied().collect(),
         }
     }
 
@@ -152,20 +155,6 @@ impl Core {
                 commands.extend(self.send_sync(self.section.clone(), self.network.clone())?);
             }
 
-            let sibling_elders = if new.prefix != old.prefix {
-                if let Some(sibling_key) = self.section_key(&new.prefix.sibling()) {
-                    self.network.get(&new.prefix.sibling()).map(|info| Elders {
-                        prefix: new.prefix.sibling(),
-                        key: *sibling_key,
-                        elders: info.elders.keys().copied().collect(),
-                    })
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-
             let self_status_change = if !old.is_elder && new.is_elder {
                 info!("Promoted to elder");
                 NodeElderChange::Promoted
@@ -178,23 +167,53 @@ impl Core {
                 NodeElderChange::None
             };
 
+            let current: BTreeSet<_> = self.section.elders().copied().collect();
+            let added = current.difference(&old.elders).copied().collect();
+            let removed = old.elders.difference(&current).copied().collect();
+            let existing = old.elders.intersection(&current).copied().collect();
+
             let elders = Elders {
                 prefix: new.prefix,
                 key: new.last_key,
-                elders: self
-                    .section
-                    .authority_provider()
-                    .elders
-                    .keys()
-                    .copied()
-                    .collect(),
+                existing,
+                added,
+                removed,
             };
 
-            self.send_event(Event::EldersChanged {
-                elders,
-                sibling_elders,
-                self_status_change,
-            });
+            let sibling_elders = if new.prefix != old.prefix {
+                if let Some(sibling_key) = self.section_key(&new.prefix.sibling()) {
+                    self.network.get(&new.prefix.sibling()).map(|info| Elders {
+                        prefix: new.prefix.sibling(),
+                        key: *sibling_key,
+                        existing: info
+                            .elders
+                            .iter()
+                            .map(|(name, addr)| Peer::new(*name, *addr))
+                            .collect(),
+                        added: BTreeSet::new(),
+                        removed: BTreeSet::new(),
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            let event = if let Some(sibling_elders) = sibling_elders {
+                Event::SectionSplit {
+                    elders,
+                    sibling_elders,
+                    self_status_change,
+                }
+            } else {
+                Event::EldersChanged {
+                    elders,
+                    self_status_change,
+                }
+            };
+
+            self.send_event(event);
         }
 
         if !new.is_elder {
@@ -232,4 +251,5 @@ pub(crate) struct StateSnapshot {
     is_elder: bool,
     last_key: bls::PublicKey,
     prefix: Prefix,
+    elders: BTreeSet<Peer>,
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -46,7 +46,7 @@ use sn_messaging::{
     section_info::{Error as TargetSectionError, Message as SectionInfoMsg},
     DstLocation, EndUser, Itinerary, MessageType, WireMsg,
 };
-use std::{net::SocketAddr, sync::Arc};
+use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
 use tokio::{sync::mpsc, task};
 use xor_name::{Prefix, XorName};
 
@@ -117,17 +117,13 @@ impl Routing {
             let elders = Elders {
                 prefix: *section.prefix(),
                 key: *section.chain().last_key(),
-                elders: section
-                    .authority_provider()
-                    .elders
-                    .keys()
-                    .copied()
-                    .collect(),
+                existing: BTreeSet::new(),
+                added: section.elders().copied().collect(),
+                removed: BTreeSet::new(),
             };
 
             state.send_event(Event::EldersChanged {
                 elders,
-                sibling_elders: None,
                 self_status_change: NodeElderChange::Promoted,
             });
 

--- a/src/routing/tests/mod.rs
+++ b/src/routing/tests/mod.rs
@@ -1246,7 +1246,7 @@ async fn handle_sync() -> Result<()> {
             .chain(iter::once(new_peer)),
         old_section_auth.prefix,
     );
-    let new_elders: BTreeSet<_> = new_section_auth.elders.keys().copied().collect();
+    let new_section_elders: BTreeSet<_> = new_section_auth.elders.keys().copied().collect();
     let proven_new_section_auth = proven(&sk2, new_section_auth)?;
     let new_section = Section::new(pk0, chain, proven_new_section_auth)?;
 
@@ -1275,7 +1275,9 @@ async fn handle_sync() -> Result<()> {
         event_rx.recv().await,
         Some(Event::EldersChanged { elders, .. }) => {
             assert_eq!(elders.key, pk2);
-            assert_eq!(elders.elders, new_elders);
+            assert!(elders.added.iter().all(|a| new_section_elders.contains(a.name())));
+            assert!(elders.existing.iter().all(|a| new_section_elders.contains(a.name())));
+            assert!(elders.removed.iter().all(|r| !new_section_elders.contains(r.name())));
         }
     );
 
@@ -1690,7 +1692,9 @@ async fn handle_elders_update() -> Result<()> {
         event_rx.recv().await,
         Some(Event::EldersChanged { elders, .. }) => {
             assert_eq!(elders.key, pk1);
-            assert_eq!(elders.elders, elder_names1);
+            assert!(elders.added.iter().all(|a| elder_names1.contains(a.name())));
+            assert!(elders.existing.iter().all(|a| elder_names1.contains(a.name())));
+            assert!(elders.removed.iter().all(|r| !elder_names1.contains(r.name())));
         }
     );
 

--- a/src/section/mod.rs
+++ b/src/section/mod.rs
@@ -263,6 +263,13 @@ impl Section {
             .map(|info| &info.peer)
     }
 
+    /// Returns elders from our section.
+    pub fn elders(&self) -> impl Iterator<Item = &Peer> {
+        self.members
+            .mature()
+            .filter(move |peer| self.is_elder(peer.name()))
+    }
+
     /// Returns adults from our section.
     pub fn adults(&self) -> impl Iterator<Item = &Peer> {
         self.members

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -37,7 +37,7 @@ async fn test_node_drop() -> Result<()> {
             continue;
         }
 
-        assert_event!(events, Event::EldersChanged { elders, .. } if elders.elders.len() == node_count);
+        assert_event!(events, Event::EldersChanged { elders, .. } if (elders.existing.len() + elders.added.len()) == node_count);
     }
 
     // Drop one node


### PR DESCRIPTION
- Removes the `sibling_elders: Option<Elders>` field from `EldersChanged`.
- Increases event data granularity by detailing the actual changes.
- Same granularity applied to `AdultsChanged`.