### PR TITLE
refactor(event): add SectionSplit, increase granularity

### DIFF
--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -236,14 +236,23 @@ async fn handle_event(index: usize, node: &mut Routing, event: Event) -> bool {
         Event::MemberLeft { name, age } => {
             info!("Node #{} member left - name: {}, age: {}", index, name, age);
         }
-        Event::EldersChanged {
+        Event::SectionSplit {
             elders,
             sibling_elders,
             self_status_change,
         } => {
             info!(
-                "Node #{} elders changed - prefix: {:b}, key: {:?}, sibling elders: {:?}, elders: {:?}, node elder status change: {:?}",
-                index, elders.prefix, elders.key, sibling_elders, elders.elders, self_status_change
+                "Node #{} section split - elders: {:?}, sibling elders: {:?}, node elder status change: {:?}",
+                index, elders, sibling_elders, self_status_change
+            );
+        }
+        Event::EldersChanged {
+            elders,
+            self_status_change,
+        } => {
+            info!(
+                "Node #{} elders changed - elders: {:?}, node elder status change: {:?}",
+                index, elders, self_status_change
             );
         }
         Event::MessageReceived {
@@ -275,8 +284,15 @@ async fn handle_event(index: usize, node: &mut Routing, event: Event) -> bool {
             index, user, msg
         ),
         Event::ClientLost(addr) => info!("Node #{} received ClientLost({:?})", index, addr),
-        Event::AdultsChanged(adult_list) => {
-            info!("Node #{} received AdultsChanged({:?})", index, adult_list)
+        Event::AdultsChanged {
+            remaining,
+            added,
+            removed,
+        } => {
+            info!(
+                "Node #{} adults changed - remaining: {:?}, added: {:?}, removed: {:?}",
+                index, remaining, added, removed
+            )
         }
     }
 

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -313,10 +313,10 @@ impl Network {
                     {
                         *prefix = elders.prefix;
 
-                        if elders.elders.contains(name) {
+                        if elders.added.contains(name) {
                             *elder = Some(ElderState {
                                 key: elders.key,
-                                num_elders: elders.elders.len(),
+                                num_elders: elders.remaining.len() + elders.added.len(),
                             });
                         } else {
                             *elder = None;

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -46,7 +46,7 @@ use sn_messaging::{
     section_info::{Error as TargetSectionError, Message as SectionInfoMsg},
     DstLocation, EndUser, Itinerary, MessageType, WireMsg,
 };
-use std::{net::SocketAddr, sync::Arc};
+use std::{collections::BTreeSet, net::SocketAddr, sync::Arc};
 use tokio::{sync::mpsc, task};
 use xor_name::{Prefix, XorName};
 
@@ -117,17 +117,18 @@ impl Routing {
             let elders = Elders {
                 prefix: *section.prefix(),
                 key: *section.chain().last_key(),
-                elders: section
+                remaining: BTreeSet::new(),
+                added: section
                     .authority_provider()
                     .elders
                     .keys()
                     .copied()
                     .collect(),
+                removed: BTreeSet::new(),
             };
 
             state.send_event(Event::EldersChanged {
                 elders,
-                sibling_elders: None,
                 self_status_change: NodeElderChange::Promoted,
             });
 

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -37,7 +37,7 @@ async fn test_node_drop() -> Result<()> {
             continue;
         }
 
-        assert_event!(events, Event::EldersChanged { elders, .. } if elders.elders.len() == node_count);
+        assert_event!(events, Event::EldersChanged { elders, .. } if (elders.remaining.len() + elders.added.len()) == node_count);
     }
 
     // Drop one node


### PR DESCRIPTION
- Removes the `sibling_elders: Option<Elders>` field from `EldersChanged`.
- Increases event data granularity by detailing the actual changes.
- Same granularity applied to `AdultsChanged`.
BREAKING CHANGE: `Event` enum variants changed and new added.