### PR TITLE
Add documentation to Cache and fix a possible bug

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -115,7 +115,7 @@ jobs:
       # Install and run cargo udeps to find unused cargo dependencies
       - name: cargo-udeps unused dependency check
         run: |
-          cargo install cargo-udeps --locked
+          cargo install cargo-udeps
           cargo +nightly udeps --all-targets
 
   cargo-deny:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ thiserror = "1.0.23"
 tokio = "1.3.0"
 xor_name = "1.1.0"
 secured_linked_list = "0.1.1"
-dashmap = "~4.0.2"
 
   [dependencies.bls]
   package = "threshold_crypto"

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -116,9 +116,8 @@ where
     }
 
     /// Remove expired items from the cache storage.
-    #[allow(unused_assignments)]
     pub async fn remove_expired(&self) {
-        let mut expired_keys = Vec::new();
+        let expired_keys: Vec<_>;
         {
             let read_items = self.items.read().await;
             expired_keys = read_items
@@ -134,12 +133,11 @@ where
     }
 
     /// Remove items that exceed capacity, oldest first.
-    #[allow(unused_assignments)]
     async fn drop_excess(&self) {
         let len = self.len().await;
         if len > self.capacity {
             let excess = len - self.capacity;
-            let mut excess_keys = Vec::new();
+            let excess_keys: Vec<_>;
             {
                 let read_items = self.items.read().await;
                 let mut items = read_items.iter().collect_vec();


### PR DESCRIPTION
- e8ed35b8 **docs(cache): Populate empty doc comments**


- a67164c7 **refactor(cache): Avoid suppressing lints**


- b5dab42c **fix(cache): Prevent exposing expired values from Cache::set**

  `Cache::set` was not testing the removed item's expiry, meaning expired
  values could be returned.

- 93de8c87 **ci: Install cargo-udeps without --locked**

  This works around a compilation issue caused by
  https://github.com/rust-lang/rust/issues/85574. A more permanent fix may
  come in future.

- 37fc9daf **chore: Remove unused dashmap dependency**

  This has been unused since #2556.
