### PR TITLE
refactor(comm): use update qp2p API logic

### DIFF
--- a/src/cache/item.rs
+++ b/src/cache/item.rs
@@ -48,13 +48,13 @@ mod tests {
     #[tokio::test]
     async fn not_expired_when_duration_is_none() {
         let item = Item::new(OBJECT, None);
-        assert_eq!(item.expired(), false);
+        assert!(!item.expired());
     }
 
     #[tokio::test]
     async fn expired_when_duration_is_zero() {
         let item = Item::new(OBJECT, Some(Duration::new(0, 0)));
         tokio::time::sleep(Duration::new(0, 0)).await;
-        assert_eq!(item.expired(), true);
+        assert!(item.expired());
     }
 }

--- a/src/routing/comm.rs
+++ b/src/routing/comm.rs
@@ -124,7 +124,7 @@ impl Comm {
 
         let bytes = msg.serialize()?;
         self.endpoint
-            .send_message(bytes, &recipient.1)
+            .try_send_message(bytes, &recipient.1)
             .await
             .map_err(|err| {
                 error!("Sending to {:?} failed with {}", recipient, err);
@@ -279,19 +279,6 @@ impl Comm {
     // Low-level send
     async fn send_to(&self, recipient: &SocketAddr, msg: Bytes) -> Result<(), qp2p::Error> {
         trace!("Low level send for msg over qp2p");
-        // This will attempt to use a cached connection
-        if self
-            .endpoint
-            .send_message(msg.clone(), recipient)
-            .await
-            .is_ok()
-        {
-            return Ok(());
-        }
-
-        // If the sending of a message failed the connection would no longer
-        // exist in the pool. So we connect again and then send the message.
-        self.endpoint.connect_to(recipient).await?;
         self.endpoint.send_message(msg, recipient).await
     }
 }

--- a/src/routing/core/connectivity.rs
+++ b/src/routing/core/connectivity.rs
@@ -155,7 +155,7 @@ impl Core {
         let mut result: Vec<Command> = Vec::new();
         for name in names.iter() {
             if let Some(info) = self.section.members().get(name) {
-                let info = info.clone().leave()?;
+                let info = info.leave()?;
                 if let Ok(commands) = self.send_proposal(&elders, Proposal::Offline(info)) {
                     result.extend(commands);
                 }

--- a/src/routing/tests/mod.rs
+++ b/src/routing/tests/mod.rs
@@ -1498,7 +1498,7 @@ async fn message_to_self(dst: MessageDst) -> Result<()> {
         assert_eq!(dest_info.dest, dst_name);
         assert_matches!(
             &message.variant,
-            Variant::UserMessage(actual_content) if Bytes::from(actual_content.clone()) == content
+            Variant::UserMessage(actual_content) if actual_content.clone() == content
         );
     });
 


### PR DESCRIPTION
- try_send on existing connection or create new connection and send
logic has been moved to qp2p
- don't create a new connection when trying to send back a message via
an existing connection (for clients)
